### PR TITLE
Fix an error where the geolocate dialog wasn't loading properly

### DIFF
--- a/src/controller/mainController.py
+++ b/src/controller/mainController.py
@@ -923,7 +923,7 @@ class Controller(object):
     x = tweet["coordinates"]["coordinates"][0]
     y = tweet["coordinates"]["coordinates"][1]
     address = geocoder.reverse_geocode(y, x)
-    dlg = messages.viewTweet(address[0].__str__(), False)
+    dlg = commonMessageDialogs.view_geodata(address[0].__str__())
    else:
     output.speak(_(u"There are no coordinates in this tweet"))
   except GeocoderError:

--- a/src/wxUI/commonMessageDialogs.py
+++ b/src/wxUI/commonMessageDialogs.py
@@ -64,3 +64,7 @@ def no_followers():
 
 def no_friends():
  return wx.MessageDialog(None, _(u"This user has no friends. {0} can't create a timeline.").format(application.name), _(u"Error"), wx.ICON_ERROR).ShowModal()
+
+def view_geodata(geotext):
+ """Specific message dialog to display geolocation data"""
+ return wx.MessageDialog(None, _(u"Geolocation data: {0}").format(geotext), _(u"Geo data for this tweet")).ShowModal()


### PR DESCRIPTION
For some reason, a standard tweet dialog was being used to display this information, which comes along with spell check, translate, etc; functions a simple geolocate display box doesn't need.
The error was happening because the tweet show dialog was accepting (tweet, tweetList, is_tweet=True) as args, and the call to display the geodata was only providing geodata as tweet, and false as tweetList.
This method signature was erroring out because is_tweet was set to True by default; the False was being accepted as tweetList, which the method later tries to call **str** which it doesn't have.
I could have just added the is_tweet keyword, but then I would need to change the signature so tweetList is set to none by default, update the method, bla, bla, bla. Too much work.
Instead I added another function in wxUI.commonMessageDialogs called view_geodata, which just accepts the data in question as an argument and displays that in a message box.
