### PR TITLE
post-abandonment : stage I

### DIFF
--- a/src/app-configuration.defaults
+++ b/src/app-configuration.defaults
@@ -15,6 +15,7 @@ speak_ready_msg = boolean(default=True)
 log_level = string(default="error")
 load_keymap = string(default="default.keymap")
 donation_dialog_displayed = boolean(default=False)
+check_for_updates = boolean(default=True)
 
 [proxy]
 server = string(default="")

--- a/src/controller/settings.py
+++ b/src/controller/settings.py
@@ -69,6 +69,8 @@ class globalSettingsController(object):
   self.dialog.set_value("proxy", "port", config.app["proxy"]["port"])
   self.dialog.set_value("proxy", "user", config.app["proxy"]["user"])
   self.dialog.set_value("proxy", "password", config.app["proxy"]["password"])
+  self.dialog.create_postabandonment()
+  self.dialog.set_value("postabandonment", "check_for_updates", config.app["app-settings"]["check_for_updates"])
   self.dialog.realize()
   self.response = self.dialog.get_response()
 
@@ -99,6 +101,7 @@ class globalSettingsController(object):
    config.app["proxy"]["port"] = self.dialog.get_value("proxy", "port")
    config.app["proxy"]["user"] = self.dialog.get_value("proxy", "user")
    config.app["proxy"]["password"] = self.dialog.get_value("proxy", "password")
+  config.app["app-settings"]["check_for_updates"] = self.dialog.get_value("postabandonment", "check_for_updates")
   config.app.write()
 
 class accountSettingsController(globalSettingsController):

--- a/src/main.py
+++ b/src/main.py
@@ -70,7 +70,8 @@ def setup():
  if system == "Windows":
   if config.app["app-settings"]["donation_dialog_displayed"] == False:
    donation()
-  updater.do_update()
+  if config.app['app-settings']['check_for_updates']:
+   updater.do_update()
  sm = sessionManager.sessionManagerController()
  sm.fill_list()
  if len(sm.sessions) == 0: sm.show()

--- a/src/wxUI/dialogs/configuration.py
+++ b/src/wxUI/dialogs/configuration.py
@@ -72,6 +72,13 @@ class proxy(wx.Panel, baseDialog.BaseWXDialog):
   sizer.Add(serverBox, 0, wx.ALL, 5)
   self.SetSizer(sizer)
 
+class postabandonment(wx.Panel, baseDialog.BaseWXDialog):
+ def __init__(self, parent):
+  super(postabandonment, self).__init__(parent)
+  sizer = wx.BoxSizer(wx.VERTICAL)
+  self.check_for_updates = wx.CheckBox(self, -1, _(U"Check for updates when {0} launches").format(application.name,))
+  sizer.Add(self.check_for_updates, 0, wx.ALL, 5)
+
 class generalAccount(wx.Panel, baseDialog.BaseWXDialog):
  def __init__(self, parent):
   super(generalAccount, self).__init__(parent)
@@ -300,7 +307,6 @@ class servicesPanel(wx.Panel):
   return self.pocketBtn.GetLabel()
 
 class configurationDialog(baseDialog.BaseWXDialog):
-
  def set_title(self, title):
   self.SetTitle(title)
 
@@ -319,6 +325,10 @@ class configurationDialog(baseDialog.BaseWXDialog):
  def create_proxy(self):
   self.proxy = proxy(self.notebook)
   self.notebook.AddPage(self.proxy, _(u"Proxy"))
+
+ def create_postabandonment(self):
+  self.postabandonment = postabandonment(self.notebook)
+  self.notebook.AddPage(self.postabandonment, _(u"Codeofdusk's post-abandonment fixes"))
 
  def create_general_account(self):
   self.general = generalAccount(self.notebook)


### PR DESCRIPTION
This is the first in a series of "post-abandonment" fixes to allow the client to independently run after the maintainer officially abandons it. This first change fixed #76 by allowing the user to disable update checks when the client launches.
