### PR TITLE
post-abandonment: user-defined keyring overrides

### DIFF
--- a/src/app-configuration.defaults
+++ b/src/app-configuration.defaults
@@ -16,6 +16,8 @@ log_level = string(default="error")
 load_keymap = string(default="default.keymap")
 donation_dialog_displayed = boolean(default=False)
 check_for_updates = boolean(default=True)
+api_key_override = string(default="")
+api_secret_override = string(default="")
 
 [proxy]
 server = string(default="")

--- a/src/controller/settings.py
+++ b/src/controller/settings.py
@@ -71,6 +71,8 @@ class globalSettingsController(object):
   self.dialog.set_value("proxy", "password", config.app["proxy"]["password"])
   self.dialog.create_postabandonment()
   self.dialog.set_value("postabandonment", "check_for_updates", config.app["app-settings"]["check_for_updates"])
+  self.dialog.set_value("postabandonment", "api_key_override", config.app["app-settings"]["api_key_override"])
+  self.dialog.set_value("postabandonment", "api_secret_override", config.app["app-settings"]["api_secret_override"])
   self.dialog.realize()
   self.response = self.dialog.get_response()
 
@@ -102,6 +104,13 @@ class globalSettingsController(object):
    config.app["proxy"]["user"] = self.dialog.get_value("proxy", "user")
    config.app["proxy"]["password"] = self.dialog.get_value("proxy", "password")
   config.app["app-settings"]["check_for_updates"] = self.dialog.get_value("postabandonment", "check_for_updates")
+  if config.app["app-settings"]["api_key_override"] != self.dialog.get_value("postabandonment", "api_key_override"):
+   config.app["app-settings"]["api_key_override"] = self.dialog.get_value("postabandonment", "api_key_override")
+   self.needs_restart=True
+  if config.app["app-settings"]["api_secret_override"] != self.dialog.get_value("postabandonment", "api_secret_override"):
+   config.app["app-settings"]["api_secret_override"] = self.dialog.get_value("postabandonment", "api_secret_override")
+   self.needs_restart=True
+  #Todo: delete sessions when API key/secrets are changed.
   config.app.write()
 
 class accountSettingsController(globalSettingsController):

--- a/src/keys/__init__.py
+++ b/src/keys/__init__.py
@@ -5,6 +5,7 @@ import exceptions
 from ctypes import c_char_p
 from libloader import load_library
 import paths
+import config
 #if application.snapshot == True:
 #	if platform.architecture()[0][:2] == "32":
 #		lib = load_library("snapshot_api_keys32", x86_path=paths.app_path("keys/lib"))
@@ -38,4 +39,9 @@ class Keyring(object):
 	def get(self, func):
 		if hasattr(application,func+"_override"):
 			return getattr(application,func+'_override')
+		try:
+			if config.app != None and config.app['app-settings'][func+"_override"] != "":
+				return config.app['app-settings'][func+"_override"]
+		except KeyError:
+			pass
 		return getattr(self, "_call_method")("get_"+func)

--- a/src/wxUI/dialogs/configuration.py
+++ b/src/wxUI/dialogs/configuration.py
@@ -42,7 +42,6 @@ class general(wx.Panel, baseDialog.BaseWXDialog):
   self.SetSizer(sizer)
 
 class proxy(wx.Panel, baseDialog.BaseWXDialog):
-
  def __init__(self, parent):
   super(proxy, self).__init__(parent)
   sizer = wx.BoxSizer(wx.VERTICAL)
@@ -78,6 +77,18 @@ class postabandonment(wx.Panel, baseDialog.BaseWXDialog):
   sizer = wx.BoxSizer(wx.VERTICAL)
   self.check_for_updates = wx.CheckBox(self, -1, _(U"Check for updates when {0} launches").format(application.name,))
   sizer.Add(self.check_for_updates, 0, wx.ALL, 5)
+  lbl = wx.StaticText(self, wx.NewId(), _(u"custom Twitter API key: "))
+  self.api_key_override = wx.TextCtrl(self, -1)
+  APIKeyBox = wx.BoxSizer(wx.HORIZONTAL)
+  APIKeyBox.Add(lbl, 0, wx.ALL, 5)
+  APIKeyBox.Add(self.api_key_override, 0, wx.ALL, 5)
+  sizer.Add(APIKeyBox, 0, wx.ALL, 5)
+  lbl = wx.StaticText(self, wx.NewId(), _(u"custom Twitter API secret: "))
+  self.api_secret_override = wx.TextCtrl(self, -1)
+  APISecretBox = wx.BoxSizer(wx.HORIZONTAL)
+  APISecretBox.Add(lbl, 0, wx.ALL, 5)
+  APISecretBox.Add(self.api_secret_override, 0, wx.ALL, 5)
+  sizer.Add(APISecretBox, 0, wx.ALL, 5)
 
 class generalAccount(wx.Panel, baseDialog.BaseWXDialog):
  def __init__(self, parent):


### PR DESCRIPTION
As part of my post-abandonment patches, these changes allow the user to override any key in the keyring. A custom Twitter API key/secret option has been added to the UI.
