### PR TITLE
Fixed a bug with galician, vasque and catala languages and arrow when selecting user default as application's language.

### DIFF
--- a/src/fixes/fix_arrow.py
+++ b/src/fixes/fix_arrow.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 from arrow import locales
 from arrow.locales import Locale
 
@@ -23,7 +23,7 @@ def get_locale(name):
 	return locale_cls()
 
 class CatalaLocale(Locale):
-	names = ['ca', 'ca_ca']
+	names = ['ca', 'ca_es', 'ca_ca']
 	past = 'Fa {0}'
 	future = '{0}' # I don't know what's the right phrase in catala for the future.
 
@@ -48,9 +48,9 @@ class CatalaLocale(Locale):
 	day_abbreviations = ['', 'Dilluns', 'Dimars', 'Dimecres', 'Dijous', 'Divendres', 'Disabte', 'Diumenge']
 
 class GalicianLocale(Locale):
-	names = ['gl', 'gl_gl']
+	names = ['gl', 'gl_es', 'gl_gl']
 	past = 'Fai {0}'
-	future = '{0}' # I don't know what's the right phrase in Galician for the future.
+	future = 'En {0}'
 
 	timeframes = {
 		'now': 'Agora mesmo',
@@ -73,7 +73,7 @@ class GalicianLocale(Locale):
 	day_abbreviations = ['', 'Lun', 'Mar', 'Mer', 'xov', 'Ven' 'Sab', 'Dom']
 
 class BasqueLocale(Locale):
-	names = ['eu', 'eu_eu']
+	names = ['eu', 'eu_es', 'eu_eu']
 	past = 'duela {0}'
 	future = '{0} igarota'
 


### PR DESCRIPTION
When application language was "system" and it was set to gl_es, eu_es or cat_es, arrow automatically have switched to english dued to an error naming the galician (gl, gl_gl>gl, gl_es, gl_gl), vasque (eu, eu_eu>eu, eu_es, eu_eu) and catalan(ca, ca_ca>ca, ca_es, ca_ca). Any problem please comment.
Note: added "en" as future expression in galician, as in spanish. It remains to add this expression (future) for catalan.
