### PR TITLE
Allow users to enable/disable indications of audio tweets, geotweets and image tweets with sound

### DIFF
--- a/src/Conf.defaults
+++ b/src/Conf.defaults
@@ -22,6 +22,9 @@ input_device = string(default="Default")
 output_device = string(default="Default")
 session_mute = boolean(default=False)
 current_soundpack = string(default="default")
+indicate_audio = boolean(default=True)
+indicate_geo = boolean(default=True)
+indicate_img = boolean(default=True)
 sndup_api_key = string(default="")
 
 [other_buffers]

--- a/src/controller/buffersController.py
+++ b/src/controller/buffersController.py
@@ -591,11 +591,11 @@ class baseBufferController(bufferController):
    original_date = arrow.get(self.session.db[self.name][self.buffer.list.get_selected()]["created_at"], "ddd MMM D H:m:s Z YYYY", locale="en")
    ts = original_date.humanize(locale=languageHandler.getLanguage())
    self.buffer.list.list.SetStringItem(self.buffer.list.get_selected(), 2, ts)
-  if utils.is_audio(tweet):
+  if self.session.settings['sound']['indicate_audio'] and utils.is_audio(tweet):
    self.session.sound.play("audio.ogg")
-  if utils.is_geocoded(tweet):
+  if self.session.settings['sound']['indicate_geo'] and utils.is_geocoded(tweet):
    self.session.sound.play("geo.ogg")
-  if utils.is_media(tweet):
+  if self.session.settings['sound']['indicate_img'] and utils.is_media(tweet):
    self.session.sound.play("image.ogg")
 
 # @_tweets_exist

--- a/src/controller/settings.py
+++ b/src/controller/settings.py
@@ -155,6 +155,9 @@ class accountSettingsController(globalSettingsController):
   self.dialog.set_value("sound", "output", self.config["sound"]["output_device"])
   self.dialog.set_value("sound", "session_mute", self.config["sound"]["session_mute"])
   self.dialog.set_value("sound", "soundpack", self.config["sound"]["current_soundpack"])
+  self.dialog.set_value("sound", "indicate_audio", self.config["sound"]["indicate_audio"])
+  self.dialog.set_value("sound", "indicate_geo", self.config["sound"]["indicate_geo"])
+  self.dialog.set_value("sound", "indicate_img", self.config["sound"]["indicate_img"])
   self.dialog.create_services()
 #  if self.config["services"]["pocket_access_token"] == "":
 #   self.dialog.services.set_pocket(False)
@@ -231,6 +234,9 @@ class accountSettingsController(globalSettingsController):
   self.config["sound"]["volume"] = self.dialog.get_value("sound", "volumeCtrl")/100.0
   self.config["sound"]["session_mute"] = self.dialog.get_value("sound", "session_mute")
   self.config["sound"]["current_soundpack"] = self.dialog.sound.get("soundpack")
+  self.config["sound"]["indicate_audio"] = self.dialog.get_value("sound", "indicate_audio")
+  self.config["sound"]["indicate_geo"] = self.dialog.get_value("sound", "indicate_geo")
+  self.config["sound"]["indicate_img"] = self.dialog.get_value("sound", "indicate_img")
   self.buffer.session.sound.config = self.config["sound"]
   self.buffer.session.sound.check_soundpack()
   self.config["sound"]["sndup_api_key"] = self.dialog.get_value("services", "apiKey")

--- a/src/wxUI/dialogs/configuration.py
+++ b/src/wxUI/dialogs/configuration.py
@@ -276,6 +276,12 @@ class sound(wx.Panel):
   soundBox.Add(soundpack_label, 0, wx.ALL, 5)
   soundBox.Add(self.soundpack, 0, wx.ALL, 5)
   sizer.Add(soundBox, 0, wx.ALL, 5)
+  self.indicate_audio = wx.CheckBox(self, -1, _(u"Indicate audio tweets with sound"))
+  sizer.Add(self.indicate_audio, 0, wx.ALL, 5)
+  self.indicate_geo = wx.CheckBox(self, -1, _(u"Indicate geotweets with sound"))
+  sizer.Add(self.indicate_geo, 0, wx.ALL, 5)
+  self.indicate_img = wx.CheckBox(self, -1, _(u"Indicate tweets containing images with sound"))
+  sizer.Add(self.indicate_img, 0, wx.ALL, 5)
   self.SetSizer(sizer)
 
  def get(self, control):


### PR DESCRIPTION
All users do not want audible indications of audio tweets, geotweetss and (particularly) tweets with images. This pull request adds three settings to the sound tab of account settings to enable or disable these indications.