### PR TITLE
Unset indicate_img by default

### DIFF
--- a/src/accessible_output2/outputs/auto.py
+++ b/src/accessible_output2/outputs/auto.py
@@ -34,6 +34,7 @@ class Auto(Output):
   output = self.get_first_available_output()
   if output:
    output.speak(*args, **kwargs)
+   output.braille(*args, **kwargs)
 
  def is_system_output(self):
   output = self.get_first_available_output()


### PR DESCRIPTION
Indicate_img should not be enabled by default, as it degrades the user experience. However, users who like the feature should be able to enable it from the sound tab of account settings.