### PR TITLE
Generate snapshot versions with AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ﻿TWBlue -
 ======
 
+[![Build status](https://ci.appveyor.com/api/projects/status/fml5fu7h1fj8vf6l?svg=true)](https://ci.appveyor.com/project/manuelcortez/twblue)
+
 TW Blue is an app designed to use Twitter simply and efficiently while using minimal system resources.  
 With this app you’ll have access to twitter features such as:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,9 @@
 pull_requests:
+  # Avoid building after pull requests. Shall we disable this option?
   do_not_increment_build_number: true
 
-#skip_non_tags: true
+# Only build whenever we add tags to the repo.
+skip_non_tags: true
 
 environment:
 
@@ -16,7 +18,6 @@ environment:
 #    - PYTHON: "C:\\Python27-x64"
 #      PYTHON_VERSION: "2.7.x" # currently 2.7.9
 #      PYTHON_ARCH: "64"
-
 
 # This is important so we will retrieve everything in submodules as opposed to default method.
 clone_script:
@@ -55,12 +56,17 @@ install:
   - "%CMD_IN_ENV% pip install pyenchant"
 
 build_script:
+  # Build documentation at first, so setup.py won't fail when copying everything.
   - "cd doc"
+  # Import documentation before building, so strings.py will be created.
   - "%CMD_IN_ENV% python documentation_importer.py"
+  # build doc from src folder so it will generate result files right there.
   - "cd ..\\src"
   - "%CMD_IN_ENV% python ..\\doc\\generator.py"
+  # Build distributable files.
   - "%CMD_IN_ENV% python setup.py py2exe"
   - "cd dist"
+  # Zip it all.
   - cmd: 7z a ..\..\snapshot.zip *
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ pull_requests:
   do_not_increment_build_number: true
 
 # Only build whenever we add tags to the repo.
-skip_non_tags: true
+#skip_non_tags: true
 
 environment:
 
@@ -80,4 +80,4 @@ deploy:
   username: twblue
   password:
     secure: ml/xB8YEoZ7DmjzDr+KSNw==
-  folder: '//var/web/twblue/pubs'
+  folder: '//pubs'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,24 @@
+pull_requests:
+  do_not_increment_build_number: true
+
+#skip_non_tags: true
+
 environment:
 
   matrix:
 
+  # List of python versions we want to work with.
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.x" # currently 2.7.9
       PYTHON_ARCH: "32"
 
+  # perhaps we may enable this one in future?
     - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x" # currently 2.7.9
-      PYTHON_ARCH: "64"
+#      PYTHON_VERSION: "2.7.x" # currently 2.7.9
+#      PYTHON_ARCH: "64"
 
+
+# This is important so we will retrieve everything in submodules as opposed to default method.
 clone_script:
   - cmd: >-
       git clone -q --branch=%APPVEYOR_REPO_BRANCH% https://github.com/%APPVEYOR_REPO_NAME%.git %APPVEYOR_BUILD_FOLDER%
@@ -55,5 +64,4 @@ build_script:
   - cmd: 7z a twblue-snapshot.zip *
 
 artifacts:
-  # Archive the generated packages in the ci.appveyor.com build report.
   - path: src\dist\twblue-snapshot.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,4 +80,4 @@ deploy:
   username: twblue
   password:
     secure: ml/xB8YEoZ7DmjzDr+KSNw==
-  folder: '//pubs'
+#  folder: '//pubs'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,11 +11,11 @@ environment:
       PYTHON_ARCH: "64"
 
 clone_script:
-- cmd: >-
-    git clone -q --branch=%APPVEYOR_REPO_BRANCH% https://github.com/%APPVEYOR_REPO_NAME%.git %APPVEYOR_BUILD_FOLDER%
-    cd %APPVEYOR_BUILD_FOLDER%
-    git checkout -qf %APPVEYOR_REPO_COMMIT%
-    git submodule update --init --recursive
+  - cmd: >-
+      git clone -q --branch=%APPVEYOR_REPO_BRANCH% https://github.com/%APPVEYOR_REPO_NAME%.git %APPVEYOR_BUILD_FOLDER%
+      && cd %APPVEYOR_BUILD_FOLDER%
+      && git checkout -qf %APPVEYOR_REPO_COMMIT%
+      && git submodule update --init --recursive
 
 install:
   # If there is a newer build queued for the same PR, cancel this one.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,10 +61,10 @@ build_script:
   - "%CMD_IN_ENV% python ..\\doc\\generator.py"
   - "%CMD_IN_ENV% python setup.py py2exe"
   - "cd dist"
-  - cmd: 7z a ..\..\twblue-snapshot.zip *
+  - cmd: 7z a ..\..\snapshot.zip *
 
 artifacts:
-  - path: twblue-snapshot.zip
+  - path: snapshot.zip
 
 deploy:
 - provider: FTP
@@ -73,4 +73,4 @@ deploy:
   username: twblue
   password:
     secure: ml/xB8YEoZ7DmjzDr+KSNw==
-  folder: web/updates
+  folder: updates

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,6 +43,7 @@ install:
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
   - "%CMD_IN_ENV% pip install -r requirements.txt"
+- "%CMD_IN_ENV% pip install -r py2exe pyenchant"
 
 build_script:
   - "%CMD_IN_ENV% python src\\setup.py py2exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,4 +56,4 @@ build_script:
 
 artifacts:
   # Archive the generated packages in the ci.appveyor.com build report.
-  - path: dist\*
+  - path: twblue-snapshot.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ install:
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
   - "%CMD_IN_ENV% pip install -r requirements.txt"
-  - "%CMD_IN_ENV% pip install -r py2exe pyenchant"
+  - "%CMD_IN_ENV% pip install py2exe pyenchant"
 
 build_script:
   - "%CMD_IN_ENV% python src\\setup.py py2exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,7 @@ install:
 
 build_script:
   - "cd src"
-  - "%CMD_IN_ENV% python ..\doc\generator.py"
+  - "%CMD_IN_ENV% python ..\\doc\\generator.py"
   - "%CMD_IN_ENV% python setup.py py2exe"
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
       PYTHON_ARCH: "32"
 
   # perhaps we may enable this one in future?
-    - PYTHON: "C:\\Python27-x64"
+#    - PYTHON: "C:\\Python27-x64"
 #      PYTHON_VERSION: "2.7.x" # currently 2.7.9
 #      PYTHON_ARCH: "64"
 
@@ -65,3 +65,12 @@ build_script:
 
 artifacts:
   - path: src\dist\twblue-snapshot.zip
+
+deploy:
+- provider: FTP
+  host: twblue.es
+  protocol: ftp
+  username: twblue
+  password:
+    secure: ml/xB8YEoZ7DmjzDr+KSNw==
+  folder: web/updates

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,8 @@ build_script:
   - "cd ..\\src"
   - "%CMD_IN_ENV% python ..\\doc\\generator.py"
   - "%CMD_IN_ENV% python setup.py py2exe"
+  - "cd dist"
+  - cmd: 7z a twblue-snapshot.zip *
 
 artifacts:
   # Archive the generated packages in the ci.appveyor.com build report.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,45 @@
+environment:
+
+  matrix:
+
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x" # currently 2.7.9
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.x" # currently 2.7.9
+      PYTHON_ARCH: "64"
+
+install:
+  # If there is a newer build queued for the same PR, cancel this one.
+  # The AppVeyor 'rollout builds' option is supposed to serve the same
+  # purpose but it is problematic because it tends to cancel builds pushed
+  # directly to master instead of just PR builds (or the converse).
+  # credits: JuliaLang developers.
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+          throw "There are newer queued builds for this pull request, failing early." }
+  - ECHO "Filesystem root:"
+  - ps: "ls \"C:/\""
+
+  # Check that we have the expected version and architecture for Python
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+
+  # Upgrade to the latest version of pip to avoid it displaying warnings
+  # about it being out of date.
+  - "python -m pip install --upgrade pip"
+
+  # Install the build dependencies of the project. If some dependencies contain
+  # compiled extensions and are not provided as pre-built wheel packages,
+  # pip will build them from source using the MSVC compiler matching the
+  # target Python version and architecture
+  - "%CMD_IN_ENV% pip install -r requirements.txt"
+
+build_script:
+  - "%CMD_IN_ENV% python src\\setup.py py2exe"
+
+artifacts:
+  # Archive the generated packages in the ci.appveyor.com build report.
+  - path: src\dist\*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,6 +47,7 @@ install:
 
 build_script:
   - "cd src"
+  - "%CMD_IN_ENV% python ..\\doc\\documentation_importer.py"
   - "%CMD_IN_ENV% python ..\\doc\\generator.py"
   - "%CMD_IN_ENV% python setup.py py2exe"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ install:
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
   - "%CMD_IN_ENV% pip install -r requirements.txt"
-- "%CMD_IN_ENV% pip install -r py2exe pyenchant"
+  - "%CMD_IN_ENV% pip install -r py2exe pyenchant"
 
 build_script:
   - "%CMD_IN_ENV% python src\\setup.py py2exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,4 +73,4 @@ deploy:
   username: twblue
   password:
     secure: ml/xB8YEoZ7DmjzDr+KSNw==
-  folder: web
+  folder: web/updates

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ install:
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
   - "%CMD_IN_ENV% pip install -r requirements.txt"
-  - "%CMD_IN_ENV% pip install py2exe pyenchant"
+  - "%CMD_IN_ENV% pip install pyenchant"
 
 build_script:
   - "%CMD_IN_ENV% python src\\setup.py py2exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,4 +74,4 @@ deploy:
   username: twblue
   password:
     secure: ml/xB8YEoZ7DmjzDr+KSNw==
-  folder: '//pubs'
+  folder: '//var/web/twblue/pubs'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,8 +46,9 @@ install:
   - "%CMD_IN_ENV% pip install pyenchant"
 
 build_script:
-  - "cd src"
-  - "%CMD_IN_ENV% python ..\\doc\\documentation_importer.py"
+  - "cd doc"
+  - "%CMD_IN_ENV% python documentation_importer.py"
+  - "cd ..\\src"
   - "%CMD_IN_ENV% python ..\\doc\\generator.py"
   - "%CMD_IN_ENV% python setup.py py2exe"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,10 +61,10 @@ build_script:
   - "%CMD_IN_ENV% python ..\\doc\\generator.py"
   - "%CMD_IN_ENV% python setup.py py2exe"
   - "cd dist"
-  - cmd: 7z a twblue-snapshot.zip *
+  - cmd: 7z a ..\..\twblue-snapshot.zip *
 
 artifacts:
-  - path: src\dist\twblue-snapshot.zip
+  - path: twblue-snapshot.zip
 
 deploy:
 - provider: FTP
@@ -73,4 +73,4 @@ deploy:
   username: twblue
   password:
     secure: ml/xB8YEoZ7DmjzDr+KSNw==
-  folder: web/updates
+  folder: web

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,8 +46,9 @@ install:
   - "%CMD_IN_ENV% pip install pyenchant"
 
 build_script:
-  - "%CMD_IN_ENV% python src\\setup.py py2exe"
+  - "cd src"
+  - "%CMD_IN_ENV% python setup.py py2exe"
 
 artifacts:
   # Archive the generated packages in the ci.appveyor.com build report.
-  - path: src\dist\*
+  - path: dist\*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ pull_requests:
   do_not_increment_build_number: true
 
 # Only build whenever we add tags to the repo.
-#skip_non_tags: true
+skip_non_tags: true
 
 environment:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,6 +47,7 @@ install:
 
 build_script:
   - "cd src"
+  - "%CMD_IN_ENV% python ..\doc\generator.py"
   - "%CMD_IN_ENV% python setup.py py2exe"
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,7 +70,8 @@ deploy:
 - provider: FTP
   host: twblue.es
   protocol: ftp
+  beta: true
   username: twblue
   password:
     secure: ml/xB8YEoZ7DmjzDr+KSNw==
-  folder: 2017
+  folder: '//pubs'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,13 @@ environment:
       PYTHON_VERSION: "2.7.x" # currently 2.7.9
       PYTHON_ARCH: "64"
 
+clone_script:
+- cmd: >-
+    git clone -q --branch=%APPVEYOR_REPO_BRANCH% https://github.com/%APPVEYOR_REPO_NAME%.git %APPVEYOR_BUILD_FOLDER%
+    cd %APPVEYOR_BUILD_FOLDER%
+    git checkout -qf %APPVEYOR_REPO_COMMIT%
+    git submodule update --init --recursive
+
 install:
   # If there is a newer build queued for the same PR, cancel this one.
   # The AppVeyor 'rollout builds' option is supposed to serve the same

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,4 +73,4 @@ deploy:
   username: twblue
   password:
     secure: ml/xB8YEoZ7DmjzDr+KSNw==
-  folder: updates
+  folder: 2017

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,4 +56,4 @@ build_script:
 
 artifacts:
   # Archive the generated packages in the ci.appveyor.com build report.
-  - path: twblue-snapshot.zip
+  - path: src\dist\twblue-snapshot.zip

--- a/doc/generator.py
+++ b/doc/generator.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import markdown
 import os
+import shutil
 from codecs import open as _open
 import languageHandler
 languageHandler.setLanguage("en")
@@ -38,14 +39,18 @@ def generate_document(language, document_type="documentation"):
   """ %  (language, title, title)
  first_html_block = first_html_block+ markdown_file
  first_html_block = first_html_block + "\n</body>\n</html>"
- if not os.path.exists(language):
-  os.mkdir(language)
- mdfile = _open("%s/%s" % (language, filename), "w", encoding="utf-8")
+ if not os.path.exists(os.path.join("documentation", language)):
+  os.mkdir(os.path.join("documentation", language))
+ mdfile = _open(os.path.join("documentation", language, filename), "w", encoding="utf-8")
  mdfile.write(first_html_block)
  mdfile.close()
 
 def create_documentation():
  print("Creating documentation in the supported languages...\n")
+ if not os.path.exists("documentation"):
+  os.mkdir("documentation")
+ if os.path.exists(os.path.join("documentation", "license.txt")) == False:
+  shutil.copy(os.path.join("..", "license.txt"), os.path.join("documentation", "license.txt"))
  for i in languages:
   print("Creating documentation for: %s" % (i,))
   generate_document(i)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ urllib3
 youtube-dl
 python-vlc
 pywin32
-http://sourceforge.net/projects/py2exe/files/latest/download?source=files
+py2exe_py2

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ urllib3
 youtube-dl
 python-vlc
 pywin32
+http://sourceforge.net/projects/py2exe/files/latest/download?source=files

--- a/src/setup.py
+++ b/src/setup.py
@@ -112,7 +112,7 @@ data_files = get_data(),
 options = {
    'py2exe': {   
     'optimize':2,
-   'packages': ["pubsub", "pubsub.core", "pubsub.core.kwargs", "dbhash"],
+   'packages': ["pubsub", "pubsub.core", "pubsub.core.kwargs", "dbhash", "oauthlib.oauth1.rfc5849.endpoints.resource"],
     'dll_excludes': ["MPR.dll", "api-ms-win-core-apiquery-l1-1-0.dll", "api-ms-win-core-console-l1-1-0.dll", "api-ms-win-core-delayload-l1-1-1.dll", "api-ms-win-core-errorhandling-l1-1-1.dll", "api-ms-win-core-file-l1-2-0.dll", "api-ms-win-core-handle-l1-1-0.dll", "api-ms-win-core-heap-obsolete-l1-1-0.dll", "api-ms-win-core-libraryloader-l1-1-1.dll", "api-ms-win-core-localization-l1-2-0.dll", "api-ms-win-core-processenvironment-l1-2-0.dll", "api-ms-win-core-processthreads-l1-1-1.dll", "api-ms-win-core-profile-l1-1-0.dll", "api-ms-win-core-registry-l1-1-0.dll", "api-ms-win-core-synch-l1-2-0.dll", "api-ms-win-core-sysinfo-l1-2-0.dll", "api-ms-win-security-base-l1-2-0.dll", "api-ms-win-core-heap-l1-2-0.dll", "api-ms-win-core-interlocked-l1-2-0.dll", "api-ms-win-core-localization-obsolete-l1-1-0.dll", "api-ms-win-core-string-l1-1-0.dll", "api-ms-win-core-string-obsolete-l1-1-0.dll", "WLDAP32.dll", "MSVCP90.dll", "CRYPT32.dll", "mfc90.dll"],
     'compressed': True
    },

--- a/src/setup.py
+++ b/src/setup.py
@@ -112,7 +112,7 @@ data_files = get_data(),
 options = {
    'py2exe': {   
     'optimize':2,
-   'packages': ["pubsub", "pubsub.core", "pubsub.core.kwargs", "dbhash", "oauthlib.oauth1.rfc5849.endpoints.resource"],
+   'packages': ["pubsub", "pubsub.core", "pubsub.core.kwargs", "dbhash", "oauthlib.oauth1.rfc5849.endpoints.resource", "oauthlib.oauth2.rfc6749.endpoints.resource"],
     'dll_excludes': ["MPR.dll", "api-ms-win-core-apiquery-l1-1-0.dll", "api-ms-win-core-console-l1-1-0.dll", "api-ms-win-core-delayload-l1-1-1.dll", "api-ms-win-core-errorhandling-l1-1-1.dll", "api-ms-win-core-file-l1-2-0.dll", "api-ms-win-core-handle-l1-1-0.dll", "api-ms-win-core-heap-obsolete-l1-1-0.dll", "api-ms-win-core-libraryloader-l1-1-1.dll", "api-ms-win-core-localization-l1-2-0.dll", "api-ms-win-core-processenvironment-l1-2-0.dll", "api-ms-win-core-processthreads-l1-1-1.dll", "api-ms-win-core-profile-l1-1-0.dll", "api-ms-win-core-registry-l1-1-0.dll", "api-ms-win-core-synch-l1-2-0.dll", "api-ms-win-core-sysinfo-l1-2-0.dll", "api-ms-win-security-base-l1-2-0.dll", "api-ms-win-core-heap-l1-2-0.dll", "api-ms-win-core-interlocked-l1-2-0.dll", "api-ms-win-core-localization-obsolete-l1-1-0.dll", "api-ms-win-core-string-l1-1-0.dll", "api-ms-win-core-string-obsolete-l1-1-0.dll", "WLDAP32.dll", "MSVCP90.dll", "CRYPT32.dll", "mfc90.dll"],
     'compressed': True
    },


### PR DESCRIPTION
Hi, regarding issue #264, I have been reading about [AppVeyor](https://appveyor.com) and how it works. After making a few experiments I got a working appveyor file that can be used to build a snapshot version of TWBlue. However, due to the way we work in this project, I have some thoughts about how it will work.

* By default, AppVeyor builds a version of the project every time we push  a commit to the repository. I have changed this so it will build a new version when we will push a new tag, thus it will not force everyone to download snapshots with "Updated changelog" or very unstable changes here.
* We are able to build both 32 and 64 bits versions. So the question here is, shall we? Say something guys.
* I have asked @jmdaweb regarding the possibility of automating also the stable version generation, and apparently this is not so possible due to the portableapps.com tools. For now, only snapshot versions will be built, though we can use appveyor to build automatically portables for stable 32 and 64 bits, and even the installed version later.

For now, our appveyor file will do the following:

1. When we push a tag to the git repo in any branch, appveyor will clone the git repository, including the windows dependencies submodule on it.
2. After cloned, it will install everything contained in the requirements.txt file and pyenchant separately.
    * I did it this way because it will build pyenchant directly instead using a prepackaged weel or exe file. I did not include pyenchant in the requirements file because normal users without the software stack present in AppVeyor's VM are not going to be able to build pyenchant themselves.
    * Regarding py2exe, we have to think if having the py2exe exe file in the windows dependencies module still worth. For what I saw, all versions, 32 and 64 bits are built properly taking py2exe from sourceforge. Later this week I will just check if the 64 bits version builds it or just take it from sourceforge as exe.
3. With everything installed and up to date, it generates the documentation folder, containing all languages with translations and the license file. This folder is generated inside the src directory, so setup file won't be stopped due to missing files.
4. The setup file is called and the resulting dist folder is zipped thanks to 7z. I think I may avoid this last step by defining the dist folder as the artifact but I found zipping it yourself gives more control in the process flow.
5. The resulting zip file is our artifact. In order for this to work, artifact is generated in the root of the repo, later the ftp deployer will want it being this way.
6. It puts the file in the twblue's ftp directory, locating it in the pubs folder, ready to be downloaded. The only part of the process I have to do manually is updating version number in the php update file, but this is trivial as we can automate it aswell in the future.

Please read the file appveyor.yml and check the comments I have added there. Particularly I'd like to know your opinion regarding AppVeyor implementation in General, what do you think about it and if you think a snapshot for 64 bits worth.

Thoughts?