### PR TITLE
Fix #278

### DIFF
--- a/src/controller/mainController.py
+++ b/src/controller/mainController.py
@@ -656,6 +656,9 @@ class Controller(object):
    sessions.sessions[item].shelve()
   if system == "Windows":
    self.systrayIcon.RemoveIcon()
+   pidpath = os.path.join(os.getenv("temp"), "{}.pid".format(application.name))
+   if os.path.exists(pidpath):
+    os.remove(pidpath)
   widgetUtils.exit_application()
 
  def follow(self, *args, **kwargs):

--- a/src/wxUI/commonMessageDialogs.py
+++ b/src/wxUI/commonMessageDialogs.py
@@ -89,3 +89,6 @@ def existing_filter():
 
 def common_error(reason):
  return wx.MessageDialog(None, reason, _(u"Error"), wx.OK).ShowModal()
+
+def dead_pid():
+ return wx.MessageDialog(None, _(u"{0} quit unexpectedly the last time it was run. If the problem persists, please report it to the {0} developers.").format(application.name), _(u"Warning"), wx.OK).ShowModal()


### PR DESCRIPTION
This pull request closes #278 as described in my comment to that issue. I've tested, and it seems to work for the most part when running from source, but testing should be performed with binary builds, particularly when the user logs off and the system is shut down or rebooted (insure the unexpected shutdown dialog doesn't appear). The checks do slow down the start of the client, but hopefully not perceptibly.