### PR TITLE
Cleanup pidfile on program restart

### DIFF
--- a/src/controller/mainController.py
+++ b/src/controller/mainController.py
@@ -656,7 +656,7 @@ class Controller(object):
    sessions.sessions[item].shelve()
   if system == "Windows":
    self.systrayIcon.RemoveIcon()
-   pidpath = os.path.join(os.getenv("temp"), "{}.pid".format(application.name))
+   pidpath = os.path.join(os.getenv("temp"), "client.pid")
    if os.path.exists(pidpath):
     os.remove(pidpath)
   widgetUtils.exit_application()

--- a/src/main.py
+++ b/src/main.py
@@ -113,7 +113,7 @@ def is_running(pid):
 
 def check_pid():
  "Insures that only one copy of the application is running at a time."
- pidpath = os.path.join(os.getenv("temp"), "{}.pid".format(application.name))
+ pidpath = os.path.join(os.getenv("temp"), "client.pid")
  if os.path.exists(pidpath):
   with open(pidpath) as fin:
    pid = int(fin.read())

--- a/src/mysc/restart.py
+++ b/src/mysc/restart.py
@@ -7,5 +7,8 @@ def restart_program():
  if not hasattr(sys, "frozen"):
   args.insert(0, sys.executable)
  if sys.platform == 'win32':
+  pidpath = os.path.join(os.getenv("temp"), "client.pid")
+  if os.path.exists(pidpath):
+   os.remove(pidpath)
   args = ['"%s"' % arg for arg in args]
  os.execv(sys.executable, args)


### PR DESCRIPTION
Before this PR, `misc.restart.restart_program` did not clean up the application PID file before exiting, so the user got a notice on relaunch. This PR fixes this behavior.