### PR TITLE
fixed an UnboundLocalError in updater.py

### DIFF
--- a/src/update/updater.py
+++ b/src/update/updater.py
@@ -11,6 +11,7 @@ from .wxUpdater import *
 logger = logging.getLogger("updater")
 
 def do_update(endpoint=application.update_url):
+ result = None
  try:
   result = update.perform_update(endpoint=endpoint, current_version=application.version, app_name=application.name, update_available_callback=available_update_dialog, progress_callback=progress_callback, update_complete_callback=update_finished)
  except:


### PR DESCRIPTION
In issue #316 the user reported that the application refused to start.
In the logs an UnboundLocalError was reported in stderr.log and this PR fixes it. This may or may not fix his issue.