### PR TITLE
Add PyEnchant to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ git+https://github.com/manuelcortez/libloader
 git+https://github.com/manuelcortez/platform_utils
 git+https://github.com/manuelcortez/accessible_output2
 git+https://github.com/jmdaweb/sound_lib
+pyenchant


### PR DESCRIPTION
Since TWBlue moved to Python 3, there is no need to install PyEnchant 1.6.6 from the windows-dependencies submodule. Just tested installing from requirements, and that works.