### PR TITLE
Add twython and pyenchant to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,8 @@ backports.functools_lru_cache
 cx_freeze
 tweepy
 twitter-text-parser
+twython
+pyenchant
 git+https://github.com/manuelcortez/libloader
 git+https://github.com/manuelcortez/platform_utils
 git+https://github.com/manuelcortez/accessible_output2

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,6 @@ backports.functools_lru_cache
 cx_freeze
 tweepy
 twitter-text-parser
-twython
 pyenchant
 git+https://github.com/manuelcortez/libloader
 git+https://github.com/manuelcortez/platform_utils


### PR DESCRIPTION
The following packages have been added to "requirements.txt" because an error occurs when creating an executable file and when starting TWBlue.exe.

- pyenchant
- twython

When the migration to twython is complete, you need to remove the twython package.