### PR TITLE
Streaming API support

### DIFF
--- a/src/controller/mainController.py
+++ b/src/controller/mainController.py
@@ -1640,7 +1640,7 @@ class Controller(object):
             if buffer == None or buffer.session.db["user_name"] != user: return
             buffer.add_new_item(data)
             if buff == "home_timeline": sound_to_play = "tweet_received.ogg"
-            elif buff == "mentions_timeline": sound_to_play = "mention_received.ogg"
+            elif buff == "mentions": sound_to_play = "mention_received.ogg"
             elif buff == "sent_tweets": sound_to_play = "tweet_send.ogg"
             elif "timeline" in buff: sound_to_play = "tweet_timeline.ogg"
             else: sound_to_play = None

--- a/src/controller/mainController.py
+++ b/src/controller/mainController.py
@@ -659,6 +659,8 @@ class Controller(object):
             sessions.sessions[item].sound.cleaner.cancel()
             log.debug("Saving database for " +    sessions.sessions[item].session_id)
             sessions.sessions[item].save_persistent_data()
+            log.debug("Disconnecting streaming endpoint for session" +    sessions.sessions[item].session_id)
+            sessions.sessions[item].stop_streaming()
         if system == "Windows":
             self.systrayIcon.RemoveIcon()
             pidpath = os.path.join(os.getenv("temp"), "{}.pid".format(application.name))

--- a/src/controller/mainController.py
+++ b/src/controller/mainController.py
@@ -273,6 +273,9 @@ class Controller(object):
         if config.app["app-settings"]["speak_ready_msg"] == True:
             output.speak(_(u"Ready"))
         self.started = True
+        self.streams_checker_function = RepeatingTimer(60, self.check_streams)
+        self.streams_checker_function.start()
+
 
     def create_ignored_session_buffer(self, session):
         self.accounts.append(session.settings["twitter"]["user_name"])
@@ -1634,3 +1637,13 @@ class Controller(object):
         buffer.add_new_item(data)
         if "home_timeline" not in buffer.session.settings["other_buffers"]["muted_buffers"]:
             self.notify(buffer.session, "tweet_received.ogg")
+
+    def check_streams(self):
+        if self.started == False:
+            return
+        for i in sessions.sessions:
+            try:
+                if sessions.sessions[i].is_logged == False: continue
+                sessions.sessions[i].check_streams()
+            except TweepError: # We shouldn't allow this function to die.
+                pass

--- a/src/controller/mainController.py
+++ b/src/controller/mainController.py
@@ -655,17 +655,20 @@ class Controller(object):
         log.debug("Saving global configuration...")
         for item in sessions.sessions:
             if sessions.sessions[item].logged == False: continue
+            log.debug("Disconnecting streaming endpoint for session" +    sessions.sessions[item].session_id)
+            sessions.sessions[item].stop_streaming()
             log.debug("Disconnecting streams for %s session" % (sessions.sessions[item].session_id,))
             sessions.sessions[item].sound.cleaner.cancel()
             log.debug("Saving database for " +    sessions.sessions[item].session_id)
             sessions.sessions[item].save_persistent_data()
-            log.debug("Disconnecting streaming endpoint for session" +    sessions.sessions[item].session_id)
-            sessions.sessions[item].stop_streaming()
         if system == "Windows":
             self.systrayIcon.RemoveIcon()
             pidpath = os.path.join(os.getenv("temp"), "{}.pid".format(application.name))
             if os.path.exists(pidpath):
                 os.remove(pidpath)
+        if hasattr(self, "streams_checker_function"):
+            log.debug("Stopping stream checker...")
+            self.streams_checker_function.cancel()
         widgetUtils.exit_application()
 
     def follow(self, *args, **kwargs):

--- a/src/sessions/twitter/session.py
+++ b/src/sessions/twitter/session.py
@@ -510,9 +510,8 @@ class Session(base.baseSession):
         self.stream_thread = call_threaded(self.stream.filter, follow=self.stream_listener.users, stall_warnings=True)
 
     def stop_streaming(self):
-        if hasattr(self, "stream_thread"):
-            self.stream_thread.join()
-        log.debug("Stopping Streaming Endpoint...")
+        self.stream.running = False
+        log.debug("Stream stopped for accounr {}".format(self.db["user_name"]))
 
     def handle_new_status(self, status, user):
         """ Handles a new status present in the Streaming API. """

--- a/src/sessions/twitter/session.py
+++ b/src/sessions/twitter/session.py
@@ -538,7 +538,7 @@ class Session(base.baseSession):
             buffers_to_send.append("sent_tweets")
         for user in status.entities["user_mentions"]:
             if user["id"] == self.db["user_id"]:
-                buffers_to_send.append("mentions_timeline")
+                buffers_to_send.append("mentions")
         users_with_timeline = [user.split("-")[0] for user in self.db.keys() if user.endswith("-timeline")]
         for user in users_with_timeline:
             if status.user.id_str == user:

--- a/src/sessions/twitter/streaming.py
+++ b/src/sessions/twitter/streaming.py
@@ -1,14 +1,26 @@
 # -*- coding: utf-8 -*-
 import tweepy
+import logging
 from pubsub import pub
+
+log = logging.getLogger("sessions.twitter.streaming")
 
 class StreamListener(tweepy.StreamListener):
 
-    def __init__(self, twitter_api, user, *args, **kwargs):
+    def __init__(self, twitter_api, user, user_id, *args, **kwargs):
         super(StreamListener, self).__init__(*args, **kwargs)
         self.api = twitter_api
         self.user = user
+        self.user_id = user_id
         self.users = [str(id) for id in self.api.friends_ids()]
+        self.users.append(str(self.user_id))
+        log.debug("Started streaming object for user {}".format(self.user))
+
+    def on_connect(self):
+        pub.sendMessage("streamConnected", user=self.user)
+
+    def on_exception(self, ex):
+        log.exception("Exception received on streaming endpoint for user {}".format(self.user))
 
     def on_status(self, status):
         """ Checks data arriving as a tweet. """

--- a/src/sessions/twitter/streaming.py
+++ b/src/sessions/twitter/streaming.py
@@ -1,4 +1,10 @@
 # -*- coding: utf-8 -*-
+""" Streaming support for TWBlue. """
+import time
+import six
+import requests
+import urllib3
+import ssl
 import tweepy
 import logging
 from pubsub import pub
@@ -28,3 +34,76 @@ class StreamListener(tweepy.StreamListener):
             pub.sendMessage("newStatus", status=status, user=self.user)
 #            print(status.text)
 
+
+class Stream(tweepy.Stream):
+
+    def _run(self):
+        # Authenticate
+        url = "https://%s%s" % (self.host, self.url)
+
+        # Connect and process the stream
+        error_counter = 0
+        resp = None
+        exc_info = None
+        while self.running:
+            if self.retry_count is not None:
+                if error_counter > self.retry_count:
+                    # quit if error count greater than retry count
+                    break
+            try:
+                auth = self.auth.apply_auth()
+                resp = self.session.request('POST',
+                                            url,
+                                            data=self.body,
+                                            timeout=self.timeout,
+                                            stream=True,
+                                            auth=auth,
+                                            verify=self.verify,
+                                            proxies = self.proxies)
+                if resp.status_code != 200:
+                    if self.listener.on_error(resp.status_code) is False:
+                        break
+                    error_counter += 1
+                    if resp.status_code == 420:
+                        self.retry_time = max(self.retry_420_start,
+                                              self.retry_time)
+                    time.sleep(self.retry_time)
+                    self.retry_time = min(self.retry_time * 2,
+                                          self.retry_time_cap)
+                else:
+                    error_counter = 0
+                    self.retry_time = self.retry_time_start
+                    self.snooze_time = self.snooze_time_step
+                    self.listener.on_connect()
+                    self._read_loop(resp)
+            except (requests.ConnectionError, requests.Timeout, ssl.SSLError, urllib3.exceptions.ReadTimeoutError, urllib3.exceptions.ProtocolError) as exc:
+                # This is still necessary, as a SSLError can actually be
+                # thrown when using Requests
+                # If it's not time out treat it like any other exception
+                if isinstance(exc, ssl.SSLError):
+                    if not (exc.args and 'timed out' in str(exc.args[0])):
+                        exc_info = sys.exc_info()
+                        break
+                if self.listener.on_timeout() is False:
+                    break
+                if self.running is False:
+                    break
+                time.sleep(self.snooze_time)
+                self.snooze_time = min(self.snooze_time + self.snooze_time_step,
+                                       self.snooze_time_cap)
+            except Exception as exc:
+                exc_info = sys.exc_info()
+                # any other exception is fatal, so kill loop
+                break
+
+        # cleanup
+        self.running = False
+        if resp:
+            resp.close()
+
+        self.new_session()
+
+        if exc_info:
+            # call a handler first so that the exception can be logged.
+            self.listener.on_exception(exc_info[1])
+            six.reraise(*exc_info)

--- a/src/sessions/twitter/streaming.py
+++ b/src/sessions/twitter/streaming.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+import tweepy
+from pubsub import pub
+
+class StreamListener(tweepy.StreamListener):
+
+    def __init__(self, twitter_api, user, *args, **kwargs):
+        super(StreamListener, self).__init__(*args, **kwargs)
+        self.api = twitter_api
+        self.user = user
+        self.users = [str(id) for id in self.api.friends_ids()]
+
+    def on_status(self, status):
+        """ Checks data arriving as a tweet. """
+        if status.user.id_str in self.users:
+            pub.sendMessage("newStatus", status=status, user=self.user)
+#            print(status.text)
+


### PR DESCRIPTION
It seems we could , in theory, bring this back with some important limitations we would need to make people aware of. Yesterday I have tried some of the interesting things in V2, and realised there was an API endpoint (and tweepy support) for this even in V1.1. This endpoint is already present on V2 too, but we could implement the v1.1 part until tweepy 4, then switch to the new filtered streaming endpoint. The current branch has some very basic implementation of the feature, though is only working for streaming tweets in the home timeline. If this works relatively reliably for some time, I'll add some code to make it recover from errors (like recreating the filtered streaming stuff) and handle all other buffers. Limitations are as follows:

* Apparently this streaming endpoint only support tweets: I have tried to make some code to get direct messages working, but Twitter does not return DM'S, and I think also is unable to retrieve friends.
* We need to pass the people we want to follow in the streaming endpoint: this would be particularly tricky when we need to update the list (for example when someone follows a person). Apparently we need to destroy and recreate this object.
* Streaming API includes *all* tweets, including replies to users the current account doesn't follow. perhaps we must make this not to happen, as we could add a significant amount of tweets to users.

thoughts?