### PR TITLE
User aliases within TWBlue

### DIFF
--- a/src/Conf.defaults
+++ b/src/Conf.defaults
@@ -49,3 +49,5 @@ braille_reporting = boolean(default=True)
 speech_reporting = boolean(default=True)
 
 [filters]
+
+[user-aliases]

--- a/src/controller/mainController.py
+++ b/src/controller/mainController.py
@@ -185,6 +185,7 @@ class Controller(object):
         widgetUtils.connect_event(self.view, widgetUtils.MENU, self.report_error, self.view.reportError)
         widgetUtils.connect_event(self.view, widgetUtils.MENU, self.view_documentation, self.view.doc)
         widgetUtils.connect_event(self.view, widgetUtils.MENU, self.view_changelog, self.view.changelog)
+        widgetUtils.connect_event(self.view, widgetUtils.MENU, self.add_alias, self.view.addAlias)
         widgetUtils.connect_event(self.view, widgetUtils.MENU, self.add_to_list, self.view.addToList)
         widgetUtils.connect_event(self.view, widgetUtils.MENU, self.remove_from_list, self.view.removeFromList)
         widgetUtils.connect_event(self.view, widgetUtils.MENU, self.update_buffer, self.view.update_buffer)
@@ -753,6 +754,26 @@ class Controller(object):
         else:
             users = utils.get_all_users(tweet, buff.session)
         u = userActionsController.userActionsController(buff, users, "report")
+
+    def add_alias(self, *args, **kwargs):
+        buff = self.get_best_buffer()
+        if not hasattr(buff, "get_right_tweet"): return
+        tweet = buff.get_right_tweet()
+        if buff.type == "people":
+            users = [tweet.screen_name]
+        elif buff.type == "dm":
+            users = [buff.session.get_user(tweet.message_create["sender_id"]).screen_name]
+        else:
+            users = utils.get_all_users(tweet, buff.session)
+        dlg = dialogs.utils.addAliasDialog(_("Add an user alias"), users)
+        if dlg.get_response() == widgetUtils.OK:
+            user, alias = dlg.get_user()
+            if user == "" or alias == "":
+                return
+            user_id = buff.session.get_user_by_screen_name(user)
+            buff.session.settings["user-aliases"][str(user_id)] = alias
+            buff.session.settings.write()
+            output.speak(_("Alias has been set correctly for {}.").format(user))
 
     def post_tweet(self, event=None):
         buffer = self.get_best_buffer()

--- a/src/sessions/twitter/session.py
+++ b/src/sessions/twitter/session.py
@@ -430,9 +430,25 @@ class Session(base.baseSession):
             users = self.db["users"]
             users[user.id_str] = user
             self.db["users"] = users
+            user.name = self.get_user_alias(user)
             return user
         else:
-            return self.db["users"][str(id)]
+            user = self.db["users"][str(id)]
+            user.name = self.get_user_alias(user)
+            return user
+
+    def get_user_alias(self, user):
+        """ Retrieves an alias for the passed user model, if exists.
+        @ user Tweepy.models.user: An user object.
+        """
+        aliases = self.settings.get("user-aliases")
+        if aliases == None:
+            log.error("Aliases are not defined for this config spec.")
+            return user.name
+        user_alias = aliases.get(user.id_str)
+        if user_alias != None:
+            return user_alias
+        return user.name
 
     def get_user_by_screen_name(self, screen_name):
         """ Returns an user identifier associated with a screen_name.

--- a/src/wxUI/dialogs/utils.py
+++ b/src/wxUI/dialogs/utils.py
@@ -48,3 +48,36 @@ class selectUserDialog(baseDialog.BaseWXDialog):
     def get_user(self):
         return self.cb.GetValue()
 
+class addAliasDialog(baseDialog.BaseWXDialog):
+    def __init__(self, title, users):
+        super(addAliasDialog, self).__init__(parent=None, id=wx.ID_ANY, title=title)
+        panel = wx.Panel(self)
+        userSizer = wx.BoxSizer()
+        self.cb = wx.ComboBox(panel, -1, choices=users, value=users[0], size=wx.DefaultSize)
+        self.cb.SetFocus()
+        self.autocompletion = wx.Button(panel, -1, _(u"&Autocomplete users"))
+        userSizer.Add(wx.StaticText(panel, -1, _(u"User")), 0, wx.ALL, 5)
+        userSizer.Add(self.cb, 0, wx.ALL, 5)
+        userSizer.Add(self.autocompletion, 0, wx.ALL, 5)
+        aliasSizer = wx.BoxSizer(wx.HORIZONTAL)
+        aliasLabel = wx.StaticText(panel, wx.ID_ANY, _("Alias"))
+        self.alias = wx.TextCtrl(panel, wx.ID_ANY)
+        aliasSizer.Add(aliasLabel, 0, wx.ALL, 5)
+        aliasSizer.Add(self.alias, 0, wx.ALL, 5)
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        ok = wx.Button(panel, wx.ID_OK, _(u"OK"))
+        ok.SetDefault()
+#  ok.Bind(wx.EVT_BUTTON, self.onok)
+        cancel = wx.Button(panel, wx.ID_CANCEL, _(u"Close"))
+        btnsizer = wx.BoxSizer()
+        btnsizer.Add(ok, 0, wx.ALL, 5)
+        btnsizer.Add(cancel, 0, wx.ALL, 5)
+        sizer.Add(userSizer, 0, wx.ALL, 5)
+        sizer.Add(aliasSizer, 0, wx.ALL, 5)
+        sizer.Add(btnsizer, 0, wx.ALL, 5)
+        panel.SetSizer(sizer)
+        self.SetClientSize(sizer.CalcMin())
+
+    def get_user(self):
+        return (self.cb.GetValue(), self.alias.GetValue())
+

--- a/src/wxUI/view.py
+++ b/src/wxUI/view.py
@@ -43,6 +43,7 @@ class mainFrame(wx.Frame):
         self.follow = user.Append(wx.ID_ANY, _(u"&Actions..."))
         self.timeline = user.Append(wx.ID_ANY, _(u"&View timeline..."))
         self.dm = user.Append(wx.ID_ANY, _(u"Direct me&ssage"))
+        self.addAlias = user.Append(wx.ID_ANY, _("Add a&lias"))
         self.addToList = user.Append(wx.ID_ANY, _(u"&Add to list"))
         self.removeFromList = user.Append(wx.ID_ANY, _(u"R&emove from list"))
         self.viewLists = user.Append(wx.ID_ANY, _(u"&View lists"))


### PR DESCRIPTION
This pr adds user aliases to TWBlue. Users can define how they'd like to name anyone in Twitter. For now, the feature is only available in the menu bar within the user menu. If the user tries to add an alias for someone which already has one, the alias will be updated. Aliases are set by using the Twitter user ID, so if the targeted user changes his/her screen_name or  Display name in Twitter, aliases won't be affected at all. Finally, the feature works only for Twitter display names. We cannot change how TWBlue shows screen names as  this would cause issues when dealing with users in general.