### PR TITLE
Fixed "report an error" button not working

### DIFF
--- a/src/application.py
+++ b/src/application.py
@@ -9,6 +9,6 @@ copyright = "Copyright (C) 2013-2022, MCV Software."
 description = name+" is an app designed to use Twitter simply and efficiently while using minimal system resources. This app provides access to most Twitter  features."
 translators = ["Manuel Cortéz (English)", "Mohammed Al Shara, Hatoun Felemban (Arabic)", "Francisco Torres (Catalan)", "Manuel cortéz (Spanish)", "Sukil Etxenike Arizaleta (Basque)", "Jani Kinnunen (finnish)", "Corentin Bacqué-Cazenave (Français)", "Juan Buño (Galician)", "Steffen Schultz (German)", "Zvonimir Stanečić (Croatian)", "Robert Osztolykan (Hungarian)", "Christian Leo Mameli (Italian)", "Riku (Japanese)", "Paweł Masarczyk (Polish)", "Odenilton Júnior Santos (Portuguese)", "Florian Ionașcu, Nicușor Untilă (Romanian)", "Natalia Hedlund, Valeria Kuznetsova (Russian)", "Aleksandar Đurić (Serbian)", "Burak Yüksek (Turkish)"]
 url = "https://twblue.es"
-report_bugs_url = "https://github.com/mcvsoftware/twblue/issues"
+report_bugs_url = "https://github.com/MCV-Software/TWBlue/issues"
 supported_languages = []
 version = "11"

--- a/src/controller/mainController.py
+++ b/src/controller/mainController.py
@@ -188,6 +188,7 @@ class Controller(object):
         widgetUtils.connect_event(self.view, widgetUtils.MENU, self.remove_from_list, self.view.removeFromList)
         widgetUtils.connect_event(self.view, widgetUtils.MENU, self.update_buffer, self.view.update_buffer)
         widgetUtils.connect_event(self.view, widgetUtils.MENU, self.manage_aliases, self.view.manageAliases)
+        widgetUtils.connect_event(self.view, widgetUtils.MENU, self.report_error, self.view.reportError)
 
     def set_systray_icon(self):
         self.systrayIcon = sysTrayIcon.SysTrayIcon()
@@ -1266,3 +1267,8 @@ class Controller(object):
 #            sound_to_play = "dm_received.ogg"
 #            if "direct_messages" not in buffer.session.settings["other_buffers"]["muted_buffers"]:
 #                self.notify(buffer.session, sound_to_play)
+
+    def report_error(self, *args, **kwargs):
+        """Redirects the user to the issue page on github"""
+        log.debug("Redirecting the user to report an error...")
+        webbrowser.open_new_tab(application.report_bugs_url)


### PR DESCRIPTION
Fixed the error when a user click the "report an error" button in the help menu it doesn't work.
Modified two files:
1. `application.py`: Changed the report_bugs_url. previous url not working, displaying page not found. Changed it to https://github.com/MCV-Software/TWBlue/issues
2. `controller/mainController.py`: Added `report_error` method. It redirects the user to the above link. Next, connected the ui to the method.
Issue: https://github.com/MCV-Software/TWBlue/issues/520