### PR TITLE
fix mastodon not found search

### DIFF
--- a/src/controller/mainController.py
+++ b/src/controller/mainController.py
@@ -110,6 +110,7 @@ class Controller(object):
         pub.subscribe(self.toggle_share_settings, "toggleShare")
         pub.subscribe(self.invisible_shorcuts_changed, "invisible-shorcuts-changed")
         pub.subscribe(self.create_account_buffer, "core.create_account")
+        pub.subscribe(self.destroy_buffer, "destroy_buffer")
 
         # Twitter specific events.
         pub.subscribe(self.buffer_title_changed, "buffer-title-changed")


### PR DESCRIPTION
fixed issue of twblue creating an empty buffer when a user searches for another user and no result was found. Now, twblue will tell the user no search result was found. display dialog?
edited two files:
src/controller/maincontroller.py: added pubsub event for destroy_buffer and connected it to Controller.destroy_buffer.
src/controller/buffers/mastodon/users.py: Changed the log name from conversation to users and
when no items was returned by the api and the buffer name ends with -searchUser, destroy buffer by calling pub.sendMessage. Alert the user with output.speak.
test: it works and no error in the log files.
I couldn't implement the same for twitter, due to api key issues.