### PR TITLE
created search buffer

### DIFF
--- a/src/controller/buffers/mastodon/__init__.py
+++ b/src/controller/buffers/mastodon/__init__.py
@@ -4,3 +4,4 @@ from .mentions import MentionsBuffer
 from .conversations import ConversationBuffer, ConversationListBuffer
 from .users import UserBuffer
 from .notifications import NotificationsBuffer
+from .search import SearchBuffer

--- a/src/controller/buffers/mastodon/base.py
+++ b/src/controller/buffers/mastodon/base.py
@@ -40,7 +40,7 @@ class BaseBuffer(base.Buffer):
         self.buffer.account = account
         self.bind_events()
         self.sound = sound
-        if "-timeline" in self.name or "-followers" in self.name or "-following" in self.name:
+        if "-timeline" in self.name or "-followers" in self.name or "-following" in self.name or "searchterm" in self.name:
             self.finished_timeline = False
 
     def create_buffer(self, parent, name):

--- a/src/controller/buffers/mastodon/search.py
+++ b/src/controller/buffers/mastodon/search.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+"""
+Implements searching functionality for mastodon
+Used for searching for statuses (posts) or possibly hashtags
+"""
+
+import logging
+import time
+from pubsub import pub
+
+from .base import BaseBuffer
+import widgetUtils
+from wxUI import commonMessageDialogs
+
+
+log = logging.getLogger("controller.buffers.mastodon.search")
+
+
+class SearchBuffer(BaseBuffer):
+    """Search buffer
+    There are some methods of the Base Buffer that can't be used here
+    """
+
+    def start_stream(self, mandatory: bool=False, play_sound: bool=True, avoid_autoreading: bool=False) -> None:
+        """Start streaming
+        Parameters:
+        - mandatory [bool]: Force start stream if True
+        - play_sound [bool]: Specifies whether to play sound after receiving posts
+        avoid_autoreading [bool]: Reads the posts if set to True
+        returns [None | int]: Number of posts received
+        """
+        log.debug(f"Starting streamd for buffer {self.name} account {self.account} and type {self.type}")
+        log.debug(f"Args: {self.args}, Kwargs: {self.kwargs}")
+
+        current_time = time.time()
+        if self.execution_time == 0 or current_time-self.execution_time >= 180 or mandatory==True:
+            self.execution_time = current_time
+
+        min_id = None
+        if self.name in self.session.db and len(self.session.db[self.name]) > 0:
+            if self.session.settings["general"]["reverse_timelines"]:
+                min_id = self.session.db[self.name][0].id
+            else:
+                min_id = self.session.db[self.name][-1].id
+        try:
+            results = getattr(self.session.api, self.function)(min_id=min_id, **self.kwargs)
+        except Exception as mess:
+            log.exception(f"Error while receiving search posts {mess}")
+            return
+
+        # Results is either in results.statuses or results.hashtags.
+        results = results.statuses if results.statuses else results.hashtags
+        results.reverse()
+        num_of_items = self.session.order_buffer(self.name, results)
+        log.debug(f"Number of items retrieved: {num_of_items}")
+        self.put_items_on_list(num_of_items)
+
+        if hasattr(self, "finished_timeline") and self.finished_timeline == False:
+            pub.sendMessage("core.change_buffer_title", name=self.session.get_name(), buffer=self.name, title=_("{}-searchterm").format(self.kwargs['q']))
+            self.finished_timeline = True
+
+            # playsound and autoread
+            if num_of_items > 0:
+                if self.sound != None and self.session.settings["sound"]["session_mute"] == False and self.name not in self.session.settings["other_buffers"]["muted_buffers"] and play_sound == True:
+                    self.session.sound.play(self.sound)
+            if avoid_autoreading == False and mandatory == True and self.name in self.session.settings["other_buffers"]["autoread_buffers"]:
+                self.auto_read(num_of_items)
+
+        return num_of_items
+
+    def remove_buffer(self, force: bool=False) -> bool:
+        """Performs clean-up tasks before removing buffer
+        Parameters:
+        - force [bool]: Force removes buffer if true
+        Returns [bool]: True proceed with removing buffer or False abort
+        removing buffer
+        """
+        # Ask user
+        if not force:
+            response = commonMessageDialogs.remove_buffer()
+        else:
+            response = widgetUtils.YES
+
+        if response == widgetUtils.NO:
+            return False
+
+        # remove references of this buffer in db and settings
+        if self.name in self.session.db:
+            self.session.db.pop(self.name)
+        if self.kwargs.get('q') in self.session.settings['other_buffers']['post_searches']:
+            self.session.settings['other_buffers']['post_searches'].remove(self.kwargs['q'])
+
+        return True

--- a/src/controller/mastodon/handler.py
+++ b/src/controller/mastodon/handler.py
@@ -150,7 +150,7 @@ class Handler(object):
                 if term not in session.settings["other_buffers"]["post_searches"]:
                     session.settings["other_buffers"]["post_searches"].append(term)
                     session.settings.write()
-#                    pub.sendMessage("createBuffer", buffer_type="SearchBuffer", session_type=session.type, buffer_title=_("Search for {}").format(term), parent_tab=searches_position, start=True, kwargs=dict(parent=controller.view.nb, function="search_tweets", name="%s-searchterm" % (term,), sessionObject=session, account=session.get_name(), bufferType="searchPanel", sound="search_updated.ogg", q=term, include_ext_alt_text=True, tweet_mode="extended"))
+                    pub.sendMessage("createBuffer", buffer_type="SearchBuffer", session_type=session.type, buffer_title=_("Search for {}").format(term), parent_tab=searches_position, start=True, kwargs=dict(parent=controller.view.nb, compose_func="compose_post", function="search", name="%s-searchterm" % (term,), sessionObject=session, account=session.get_name(), sound="search_updated.ogg", q=term, result_type="statuses"))
                 else:
                     log.error("A buffer for the %s search term is already created. You can't create a duplicate buffer." % (term,))
                     return

--- a/src/mastodon.defaults
+++ b/src/mastodon.defaults
@@ -35,6 +35,7 @@ following_timelines =  list(default=list())
 trending_topic_buffers = list(default=list())
 muted_buffers = list(default=list())
 autoread_buffers = list(default=list(mentions, direct_messages, events))
+post_searches = list(default = list())
 
 [mysc]
 spelling_language = string(default="")


### PR DESCRIPTION
Created a minimal search buffer. It definitely needs more work. I didn't wanted to go far on the wrong way.
1. created: src/controller/buffers/mastodon/search.py - It has the SearchBuffer. It inherits from BaseBuffer. It overwrites start_stream and remove_buffer. My mastodon account doesn't have enough activity for me to test pagination and create the get_more_items method. Does search really have pagination and is it ordered?
2. edited src/buffers/mastodon/__init__.py - imported SearchBuffer for Controller.create_buffer to access
3. edited src/mastodon/handler.py - edited the pub send message part of the search method to create the appropriate buffer with the appropriate info.
4. edited: mastodon.defaults - Added [other_buffers][[post_searches] list to hold already created searches. 
We could add support for hashtags with this easily. And what way should we take care of searches that yields zero results.