### PR TITLE
Create update profile

### DIFF
--- a/src/controller/mainController.py
+++ b/src/controller/mainController.py
@@ -116,6 +116,7 @@ class Controller(object):
         # connect application events to GUI
         widgetUtils.connect_event(self.view, widgetUtils.CLOSE_EVENT, self.exit_)
         widgetUtils.connect_event(self.view, widgetUtils.MENU, self.show_hide, menuitem=self.view.show_hide)
+        widgetUtils.connect_event(self.view, widgetUtils.MENU, self.update_profile, menuitem=self.view.updateProfile)
         widgetUtils.connect_event(self.view, widgetUtils.MENU, self.search, menuitem=self.view.menuitem_search)
 #        widgetUtils.connect_event(self.view, widgetUtils.MENU, self.list_manager, menuitem=self.view.lists)
         widgetUtils.connect_event(self.view, widgetUtils.MENU, self.find, menuitem=self.view.find)
@@ -1085,3 +1086,11 @@ class Controller(object):
         """Redirects the user to the issue page on github"""
         log.debug("Redirecting the user to report an error...")
         webbrowser.open_new_tab(application.report_bugs_url)
+
+    def update_profile(self, *args):
+        """Updates the users profile"""
+        log.debug("Update profile")
+        buffer = self.get_best_buffer()
+        handler = self.get_handler(buffer.session.type)
+        if handler:
+            handler.update_profile(buffer.session)

--- a/src/controller/mastodon/handler.py
+++ b/src/controller/mastodon/handler.py
@@ -265,10 +265,19 @@ class Handler(object):
         data = {
                 'display_name': profile.display_name,
                 'note': html_filter(profile.note),
+                'header': profile.header,
+                'avatar': profile.avatar,
+                'fields': [(field.name, html_filter(field.value)) for field in profile.fields],
                 }
+        log.debug(f"arafat {data['fields']}")
         dialog = update_profile_dialogs.UpdateProfileDialog(**data)
-        if dialog.ShowModal() != wx.ID_OK: return
+        if dialog.ShowModal() != wx.ID_OK:
+            log.debug("User canceled dialog")
+            return
         updated_data = dialog.data
+        if updated_data == data:
+            log.debug("No profile info was changed.")
+            return
         # remove data that hasn't been updated
         for key in data:
             if data[key] == updated_data[key]:

--- a/src/controller/mastodon/handler.py
+++ b/src/controller/mastodon/handler.py
@@ -268,6 +268,10 @@ class Handler(object):
                 'header': profile.header,
                 'avatar': profile.avatar,
                 'fields': [(field.name, html_filter(field.value)) for field in profile.fields],
+                'locked': profile.locked,
+                'bot': profile.bot,
+                # discoverable could be None, set it to False
+                'discoverable': profile.discoverable if profile.discoverable else False,
                 }
         log.debug(f"arafat {data['fields']}")
         dialog = update_profile_dialogs.UpdateProfileDialog(**data)

--- a/src/wxUI/dialogs/mastodon/updateProfile.py
+++ b/src/wxUI/dialogs/mastodon/updateProfile.py
@@ -40,14 +40,14 @@ class UpdateProfileDialog(wx.Dialog):
 
         # create widgets
         display_name_label = wx.StaticText(panel, label=_("Display Name"))
-        self.display_name = wx.TextCtrl(panel, value=display_name, style= wx.TE_PROCESS_ENTER, size=(100, 30))
+        self.display_name = wx.TextCtrl(panel, value=display_name, style= wx.TE_PROCESS_ENTER, size=(200, 30))
         name_sizer = wx.BoxSizer(wx.HORIZONTAL)
         name_sizer.Add(display_name_label, wx.SizerFlags().Center())
         name_sizer.Add(self.display_name, wx.SizerFlags().Center())
         sizer.Add(name_sizer, wx.CENTER)
 
         bio_label = wx.StaticText(panel, label=_("Bio"))
-        self.bio = wx.TextCtrl(panel, value=note, style=wx.TE_PROCESS_ENTER | wx.TE_MULTILINE, size=(200, 30))
+        self.bio = wx.TextCtrl(panel, value=note, style=wx.TE_PROCESS_ENTER | wx.TE_MULTILINE, size=(400, 60))
         bio_sizer = wx.BoxSizer(wx.HORIZONTAL)
         bio_sizer.Add(bio_label, wx.SizerFlags().Center())
         bio_sizer.Add(self.bio, wx.SizerFlags().Center())
@@ -109,7 +109,7 @@ class UpdateProfileDialog(wx.Dialog):
             content_label = wx.StaticText(panel, label=_("Content"))
             field_sizer.Add(content_label, wx.SizerFlags().Center().Border(wx.ALL, 5))
 
-            content_textctrl = wx.TextCtrl(panel, style=wx.TE_PROCESS_ENTER | wx.TE_MULTILINE, size=(200, 30))
+            content_textctrl = wx.TextCtrl(panel, style=wx.TE_PROCESS_ENTER | wx.TE_MULTILINE, size=(400, 60))
             if i <= len(fields):
                 content_textctrl.SetValue(fields[i-1][1])
             field_sizer.Add(content_textctrl, wx.SizerFlags().Expand().Border(wx.ALL, 5))

--- a/src/wxUI/dialogs/mastodon/updateProfile.py
+++ b/src/wxUI/dialogs/mastodon/updateProfile.py
@@ -1,0 +1,57 @@
+import wx
+
+
+class UpdateProfileDialog(wx.Dialog):
+    """
+    A dialog for user to update his / her profile details.
+    layout is:
+    ```
+    header
+    avatar
+    name
+    bio
+    meta data
+    ```
+    """
+
+    def __init__(self, display_name: str="", note: str=""):
+        """Initialize update profile dialog
+        Parameters:
+        - display_name: The user's display name to show in the display name field
+        - note: The users bio to show in the bio field
+        """
+        super().__init__(parent=None)
+        self.SetTitle(_("Update Profile"))
+        panel = wx.Panel(self)
+        sizer = wx.BoxSizer(wx.VERTICAL)
+
+        # create widgets
+        display_name_label = wx.StaticText(panel, label=_("Display Name"))
+        self.display_name = wx.TextCtrl(panel, value=display_name, style=
+                                        wx.TE_PROCESS_ENTER)
+        bio_label = wx.StaticText(panel, label=_("Bio"))
+        self.bio = wx.TextCtrl(panel, value=note, style=wx.TE_PROCESS_ENTER)
+        ok = wx.Button(panel, wx.ID_OK, _(u"&OK"))
+        ok.SetDefault()
+        cancel = wx.Button(panel, wx.ID_CANCEL, _("&Close"))
+        self.SetEscapeId(cancel.GetId())
+
+        # manage sizers
+        sizer.Add(display_name_label, wx.SizerFlags().Center())
+        sizer.Add(self.display_name, wx.SizerFlags().Center())
+        sizer.Add(cancel, wx.SizerFlags().Center())
+        sizer.Add(ok, wx.SizerFlags().Center())
+        sizer.Add(self.bio, wx.SizerFlags().Center())
+        panel.SetSizer(sizer)
+        panel.Fit()
+
+        # manage events
+        ok.Bind(wx.EVT_BUTTON, self.on_ok)
+
+    def on_ok(self, *args):
+        """Method called when user clicks ok in dialog"""
+        self.data = {
+                'display_name': self.display_name.GetValue(),
+                'note': self.bio.GetValue()
+                }
+        self.EndModal(wx.ID_OK)

--- a/src/wxUI/dialogs/mastodon/updateProfile.py
+++ b/src/wxUI/dialogs/mastodon/updateProfile.py
@@ -1,4 +1,13 @@
+import os
+import requests
+from io import BytesIO
+
 import wx
+
+
+from logging import getLogger;log = getLogger()
+def return_true():
+    return True
 
 
 class UpdateProfileDialog(wx.Dialog):
@@ -14,14 +23,20 @@ class UpdateProfileDialog(wx.Dialog):
     ```
     """
 
-    def __init__(self, display_name: str="", note: str=""):
+    def __init__(self, display_name: str="", note: str="", header: str="",
+                 avatar: str="", fields: list=[]):
         """Initialize update profile dialog
         Parameters:
         - display_name: The user's display name to show in the display name field
         - note: The users bio to show in the bio field
+        - header: the users header pic link
+        - avatar: The users avatar pic link
         """
         super().__init__(parent=None)
         self.SetTitle(_("Update Profile"))
+        self.header = header
+        self.avatar = avatar
+
         panel = wx.Panel(self)
         sizer = wx.BoxSizer(wx.VERTICAL)
 
@@ -31,27 +46,155 @@ class UpdateProfileDialog(wx.Dialog):
                                         wx.TE_PROCESS_ENTER)
         bio_label = wx.StaticText(panel, label=_("Bio"))
         self.bio = wx.TextCtrl(panel, value=note, style=wx.TE_PROCESS_ENTER)
+
+        # header
+        header_label = wx.StaticText(panel, label=_("Header"))
+        try:
+            response = requests.get(self.header)
+        except requests.exceptions.RequestException:
+            # Create empty image
+            self.header_image = wx.StaticBitmap()
+        else:
+            image_bytes = BytesIO(response.content)
+            image = wx.Image(image_bytes, wx.BITMAP_TYPE_ANY)
+            image.Rescale(300, 100, wx.IMAGE_QUALITY_HIGH)
+            self.header_image = wx.StaticBitmap(panel, bitmap=image.ConvertToBitmap())
+
+        self.header_image.AcceptsFocusFromKeyboard = return_true
+        self.change_header = wx.Button(panel, label=_("Change header"))
+
+        # avatar
+        avatar_label = wx.StaticText(panel, label=_("Avatar"))
+        try:
+            response = requests.get(self.avatar)
+        except requests.exceptions.RequestException:
+            # Create empty image
+            self.avatar_image = wx.StaticBitmap()
+        else:
+            image_bytes = BytesIO(response.content)
+            image = wx.Image(image_bytes, wx.BITMAP_TYPE_ANY)
+            image.Rescale(150, 150, wx.IMAGE_QUALITY_HIGH)
+            self.avatar_image = wx.StaticBitmap(panel, bitmap=image.ConvertToBitmap())
+
+        self.avatar_image.AcceptsFocusFromKeyboard = return_true
+        self.change_avatar = wx.Button(panel, label=_("Change avatar"))
+
+        self.fields = []
+        for i in range(1, 5):
+            field_sizer = wx.BoxSizer(wx.HORIZONTAL)
+            field_label = wx.StaticText(panel, label=_("Field {}: Label").format(i))
+            field_sizer.Add(field_label, wx.SizerFlags().Center().Border(wx.ALL, 5))
+
+            label_textctrl = wx.TextCtrl(panel, style=wx.TE_PROCESS_ENTER)
+            if i <= len(fields):
+                label_textctrl.SetValue(fields[i-1][0])
+                log.debug(f"Field {i}: label = {fields[i-1][0]}")
+            field_sizer.Add(label_textctrl, wx.SizerFlags().Expand().Border(wx.ALL, 5))
+
+            content_label = wx.StaticText(panel, label=_("Content"))
+            field_sizer.Add(content_label, wx.SizerFlags().Center().Border(wx.ALL, 5))
+
+            content_textctrl = wx.TextCtrl(panel, style=wx.TE_PROCESS_ENTER)
+            if i <= len(fields):
+                content_textctrl.SetValue(fields[i-1][1])
+                log.debug(f"content: {fields[i-1][1]}")
+            field_sizer.Add(content_textctrl, wx.SizerFlags().Expand().Border(wx.ALL, 5))
+            sizer.Add(field_sizer, 0, wx.CENTER)
+            self.fields.append((label_textctrl, content_textctrl))
+
         ok = wx.Button(panel, wx.ID_OK, _(u"&OK"))
         ok.SetDefault()
         cancel = wx.Button(panel, wx.ID_CANCEL, _("&Close"))
         self.SetEscapeId(cancel.GetId())
 
         # manage sizers
-        sizer.Add(display_name_label, wx.SizerFlags().Center())
-        sizer.Add(self.display_name, wx.SizerFlags().Center())
-        sizer.Add(cancel, wx.SizerFlags().Center())
-        sizer.Add(ok, wx.SizerFlags().Center())
-        sizer.Add(self.bio, wx.SizerFlags().Center())
+        name_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        name_sizer.Add(display_name_label, wx.SizerFlags().Center())
+        name_sizer.Add(self.display_name, wx.SizerFlags().Center())
+        sizer.Add(name_sizer, wx.CENTER)
+
+        bio_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        bio_sizer.Add(bio_label, wx.SizerFlags().Center())
+        bio_sizer.Add(self.bio, wx.SizerFlags().Center())
+        sizer.Add(bio_sizer, wx.CENTER)
+
+        header_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        header_sizer.Add(header_label, wx.SizerFlags().Center())
+        header_sizer.Add(self.header_image, wx.SizerFlags().Center())
+        header_sizer.Add(self.change_header, wx.SizerFlags().Center())
+        sizer.Add(header_sizer, wx.CENTER)
+
+        avatar_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        avatar_sizer.Add(avatar_label, wx.SizerFlags().Center())
+        avatar_sizer.Add(self.avatar_image, wx.SizerFlags().Center())
+        avatar_sizer.Add(self.change_avatar, wx.SizerFlags().Center())
+        sizer.Add(avatar_sizer, wx.CENTER)
+
+        action_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        action_sizer.Add(ok, wx.SizerFlags().Center())
+        action_sizer.Add(cancel, wx.SizerFlags().Center())
+        sizer.Add(action_sizer, wx.CENTER)
         panel.SetSizer(sizer)
         panel.Fit()
 
         # manage events
         ok.Bind(wx.EVT_BUTTON, self.on_ok)
+        self.change_header.Bind(wx.EVT_BUTTON, self.on_change_header)
+        self.change_avatar.Bind(wx.EVT_BUTTON, self.on_change_avatar)
+
+        self.AutoLayout = True
 
     def on_ok(self, *args):
         """Method called when user clicks ok in dialog"""
         self.data = {
                 'display_name': self.display_name.GetValue(),
-                'note': self.bio.GetValue()
+                'note': self.bio.GetValue(),
+                'header': self.header,
+                'avatar': self.avatar,
+                'fields': [(label.GetValue(), content.GetValue()) for label, content in self.fields if label.GetValue() and content.GetValue()]
                 }
         self.EndModal(wx.ID_OK)
+
+    def on_change_header(self, *args):
+        """Display a dialog for the user to choose a picture and update the
+        appropriate attribute"""
+        wildcard = "Images (*.png;*.jpg;*.gif)|*.png;*.jpg;*.gif"
+        dlg = wx.FileDialog(self, _("Select header image - max 2MB"), wildcard=wildcard)
+        if dlg.ShowModal() == wx.CLOSE:
+            return
+        if os.path.getsize(dlg.GetPath()) > 2097152:
+            # File size exceeds the limit
+            message = _("The selected file is larger than 2MB. Do you want to select another file?")
+            caption = _("File more than 2MB")
+            style = wx.YES_NO | wx.ICON_WARNING
+
+            # Display the message box
+            result = wx.MessageBox(message, caption, style)
+            return self.on_change_header() if result == wx.YES else None
+
+        self.header = dlg.GetPath()
+        image = wx.Image(self.header, wx.BITMAP_TYPE_ANY)
+        image.Rescale(150, 150, wx.IMAGE_QUALITY_HIGH)
+        self.header_image.SetBitmap(image.ConvertToBitmap())
+
+    def on_change_avatar(self, *args):
+        """Display a dialog for the user to choose a picture and update the
+        appropriate attribute"""
+        wildcard = "Images (*.png;*.jpg;*.gif)|*.png;*.jpg;*.gif"
+        dlg = wx.FileDialog(self, _("Select avatar image - max 2MB"), wildcard=wildcard)
+        if dlg.ShowModal() == wx.CLOSE:
+            return
+        if os.path.getsize(dlg.GetPath()) > 2097152:
+            # File size exceeds the limit
+            message = _("The selected file is larger than 2MB. Do you want to select another file?")
+            caption = _("File more than 2MB")
+            style = wx.YES_NO | wx.ICON_WARNING
+
+            # Display the message box
+            result = wx.MessageBox(message, caption, style)
+            return self.on_change_avatar() if result == wx.YES else None
+
+        self.avatar = dlg.GetPath()
+        image = wx.Image(self.avatar, wx.BITMAP_TYPE_ANY)
+        image.Rescale(150, 150, wx.IMAGE_QUALITY_HIGH)
+        self.avatar_image.SetBitmap(image.ConvertToBitmap())

--- a/src/wxUI/dialogs/mastodon/updateProfile.py
+++ b/src/wxUI/dialogs/mastodon/updateProfile.py
@@ -5,7 +5,6 @@ from io import BytesIO
 import wx
 
 
-from logging import getLogger;log = getLogger()
 def return_true():
     return True
 
@@ -23,8 +22,7 @@ class UpdateProfileDialog(wx.Dialog):
     ```
     """
 
-    def __init__(self, display_name: str="", note: str="", header: str="",
-                 avatar: str="", fields: list=[]):
+    def __init__(self, display_name: str, note: str, header: str, avatar: str, fields: list, locked: bool, bot: bool, discoverable: bool):
         """Initialize update profile dialog
         Parameters:
         - display_name: The user's display name to show in the display name field
@@ -42,10 +40,18 @@ class UpdateProfileDialog(wx.Dialog):
 
         # create widgets
         display_name_label = wx.StaticText(panel, label=_("Display Name"))
-        self.display_name = wx.TextCtrl(panel, value=display_name, style=
-                                        wx.TE_PROCESS_ENTER)
+        self.display_name = wx.TextCtrl(panel, value=display_name, style= wx.TE_PROCESS_ENTER, size=(100, 30))
+        name_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        name_sizer.Add(display_name_label, wx.SizerFlags().Center())
+        name_sizer.Add(self.display_name, wx.SizerFlags().Center())
+        sizer.Add(name_sizer, wx.CENTER)
+
         bio_label = wx.StaticText(panel, label=_("Bio"))
-        self.bio = wx.TextCtrl(panel, value=note, style=wx.TE_PROCESS_ENTER)
+        self.bio = wx.TextCtrl(panel, value=note, style=wx.TE_PROCESS_ENTER | wx.TE_MULTILINE, size=(200, 30))
+        bio_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        bio_sizer.Add(bio_label, wx.SizerFlags().Center())
+        bio_sizer.Add(self.bio, wx.SizerFlags().Center())
+        sizer.Add(bio_sizer, wx.CENTER)
 
         # header
         header_label = wx.StaticText(panel, label=_("Header"))
@@ -62,6 +68,11 @@ class UpdateProfileDialog(wx.Dialog):
 
         self.header_image.AcceptsFocusFromKeyboard = return_true
         self.change_header = wx.Button(panel, label=_("Change header"))
+        header_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        header_sizer.Add(header_label, wx.SizerFlags().Center())
+        header_sizer.Add(self.header_image, wx.SizerFlags().Center())
+        header_sizer.Add(self.change_header, wx.SizerFlags().Center())
+        sizer.Add(header_sizer, wx.CENTER)
 
         # avatar
         avatar_label = wx.StaticText(panel, label=_("Avatar"))
@@ -78,6 +89,11 @@ class UpdateProfileDialog(wx.Dialog):
 
         self.avatar_image.AcceptsFocusFromKeyboard = return_true
         self.change_avatar = wx.Button(panel, label=_("Change avatar"))
+        avatar_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        avatar_sizer.Add(avatar_label, wx.SizerFlags().Center())
+        avatar_sizer.Add(self.avatar_image, wx.SizerFlags().Center())
+        avatar_sizer.Add(self.change_avatar, wx.SizerFlags().Center())
+        sizer.Add(avatar_sizer, wx.CENTER)
 
         self.fields = []
         for i in range(1, 5):
@@ -85,57 +101,42 @@ class UpdateProfileDialog(wx.Dialog):
             field_label = wx.StaticText(panel, label=_("Field {}: Label").format(i))
             field_sizer.Add(field_label, wx.SizerFlags().Center().Border(wx.ALL, 5))
 
-            label_textctrl = wx.TextCtrl(panel, style=wx.TE_PROCESS_ENTER)
+            label_textctrl = wx.TextCtrl(panel, style=wx.TE_PROCESS_ENTER | wx.TE_MULTILINE, size=(200, 30))
             if i <= len(fields):
                 label_textctrl.SetValue(fields[i-1][0])
-                log.debug(f"Field {i}: label = {fields[i-1][0]}")
             field_sizer.Add(label_textctrl, wx.SizerFlags().Expand().Border(wx.ALL, 5))
 
             content_label = wx.StaticText(panel, label=_("Content"))
             field_sizer.Add(content_label, wx.SizerFlags().Center().Border(wx.ALL, 5))
 
-            content_textctrl = wx.TextCtrl(panel, style=wx.TE_PROCESS_ENTER)
+            content_textctrl = wx.TextCtrl(panel, style=wx.TE_PROCESS_ENTER | wx.TE_MULTILINE, size=(200, 30))
             if i <= len(fields):
                 content_textctrl.SetValue(fields[i-1][1])
-                log.debug(f"content: {fields[i-1][1]}")
             field_sizer.Add(content_textctrl, wx.SizerFlags().Expand().Border(wx.ALL, 5))
             sizer.Add(field_sizer, 0, wx.CENTER)
             self.fields.append((label_textctrl, content_textctrl))
+
+        self.locked = wx.CheckBox(panel, label=_("Private account"))
+        self.locked.SetValue(locked)
+        self.bot = wx.CheckBox(panel, label=_("Bot account"))
+        self.bot.SetValue(bot)
+        self.discoverable = wx.CheckBox(panel, label=_("Discoverable account"))
+        self.discoverable.SetValue(discoverable)
+        sizer.Add(self.locked, wx.SizerFlags().Expand().Border(wx.ALL, 5))
+        sizer.Add(self.bot, wx.SizerFlags().Expand().Border(wx.ALL, 5))
+        sizer.Add(self.discoverable, wx.SizerFlags().Expand().Border(wx.ALL, 5))
 
         ok = wx.Button(panel, wx.ID_OK, _(u"&OK"))
         ok.SetDefault()
         cancel = wx.Button(panel, wx.ID_CANCEL, _("&Close"))
         self.SetEscapeId(cancel.GetId())
-
-        # manage sizers
-        name_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        name_sizer.Add(display_name_label, wx.SizerFlags().Center())
-        name_sizer.Add(self.display_name, wx.SizerFlags().Center())
-        sizer.Add(name_sizer, wx.CENTER)
-
-        bio_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        bio_sizer.Add(bio_label, wx.SizerFlags().Center())
-        bio_sizer.Add(self.bio, wx.SizerFlags().Center())
-        sizer.Add(bio_sizer, wx.CENTER)
-
-        header_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        header_sizer.Add(header_label, wx.SizerFlags().Center())
-        header_sizer.Add(self.header_image, wx.SizerFlags().Center())
-        header_sizer.Add(self.change_header, wx.SizerFlags().Center())
-        sizer.Add(header_sizer, wx.CENTER)
-
-        avatar_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        avatar_sizer.Add(avatar_label, wx.SizerFlags().Center())
-        avatar_sizer.Add(self.avatar_image, wx.SizerFlags().Center())
-        avatar_sizer.Add(self.change_avatar, wx.SizerFlags().Center())
-        sizer.Add(avatar_sizer, wx.CENTER)
-
         action_sizer = wx.BoxSizer(wx.HORIZONTAL)
         action_sizer.Add(ok, wx.SizerFlags().Center())
         action_sizer.Add(cancel, wx.SizerFlags().Center())
         sizer.Add(action_sizer, wx.CENTER)
         panel.SetSizer(sizer)
-        panel.Fit()
+        sizer.Fit(self)
+        self.Center()
 
         # manage events
         ok.Bind(wx.EVT_BUTTON, self.on_ok)
@@ -151,7 +152,10 @@ class UpdateProfileDialog(wx.Dialog):
                 'note': self.bio.GetValue(),
                 'header': self.header,
                 'avatar': self.avatar,
-                'fields': [(label.GetValue(), content.GetValue()) for label, content in self.fields if label.GetValue() and content.GetValue()]
+                'fields': [(label.GetValue(), content.GetValue()) for label, content in self.fields if label.GetValue() and content.GetValue()],
+                'locked': self.locked.GetValue(),
+                'bot': self.bot.GetValue(),
+                'discoverable': self.discoverable.GetValue(),
                 }
         self.EndModal(wx.ID_OK)
 

--- a/src/wxUI/view.py
+++ b/src/wxUI/view.py
@@ -15,7 +15,6 @@ class mainFrame(wx.Frame):
         self.menubar_application = wx.Menu()
         self.manage_accounts = self.menubar_application.Append(wx.ID_ANY, _(u"&Manage accounts"))
         self.updateProfile = self.menubar_application.Append(wx.ID_ANY, _("&Update profile"))
-        self.updateProfile.Enable(False)
         self.show_hide = self.menubar_application.Append(wx.ID_ANY, _(u"&Hide window"))
         self.menuitem_search = self.menubar_application.Append(wx.ID_ANY, _(u"&Search"))
         self.lists = self.menubar_application.Append(wx.ID_ANY, _(u"&Lists manager"))


### PR DESCRIPTION
Solving this [issue](https://github.com/MCV-Software/TWBlue/issues/546#issue-1746837055).
Currently, the branch has a basic support for updating profile. It currently supports updating display names and bio. Other features will be added shortly.
Changes:
1. created: src/wxUI/dialogs/mastodon/updateProfile.py - Created UpdateProfileDialog. A dialog that has two edit boxes at this point to let the user edit his / her name and bio.
2. edited: src/wxUI/view.py - Deleted the line that disabled the "update profile" option.
3. edited: src/controller/mainController.py - Created an update_profile method and binded the "update profile" option to it. The method just calls the update_profile method of mastodon handler.
4. edited: src/controller/mastodon/handler.py - Changed updateProfile field of handler.menus attribute from None. This is to stop controller.update_menus from disabling it. Next, created a update_profile method. It gets the current profile, open the update profile dialog and updates whatever the user changes.
