### PR TITLE
Fixed documentation generation step in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Now that you have installed all these packages, you can run TW Blue from source 
 
 To generate the documentation in html format, navigate to the doc folder inside this repo. After that, run these commands:  
 
-    `python document_importer.py`  
+    `python documentation_importer.py`  
     `python generator.py`  
 
 The documentation will be generated, placing each language in a separate folder in the doc directory. Move these folders (for example `de`, `en`, `es`, `fr`, `it`, ...) to `src/documentation`, creating the directory if necessary.  


### PR DESCRIPTION
Following the instructions in the README to generate TWBlue documentation doesn't work. The instruction is to run `python document_importer.py`.
There is no file `document_importer.py` in the `doc` directory.
Changed it to `documentation_importer.py`. `documentation_importer.py` exist and I think that is the file that is supposed to be executed.