### PR TITLE
Mastodon: Loads pinned posts in user timelines and supports announcing when the focused post is pinned

### DIFF
--- a/src/controller/buffers/mastodon/base.py
+++ b/src/controller/buffers/mastodon/base.py
@@ -121,9 +121,13 @@ class BaseBuffer(base.Buffer):
             except Exception as e:
                 log.exception("Error %s" % (str(e)))
                 return
-            if pinned_posts != None and len(pinned_posts) > 0:
-                amount_of_pinned_posts = self.session.order_buffer(self.name, pinned_posts)
+            if self.session.settings["general"]["reverse_timelines"]:
+                if pinned_posts != None and len(pinned_posts) > 0:
+                    amount_of_pinned_posts = self.session.order_buffer(self.name, pinned_posts)
             number_of_items = self.session.order_buffer(self.name, results)
+            if self.session.settings["general"]["reverse_timelines"] == False:
+                if pinned_posts != None and len(pinned_posts) > 0:
+                    amount_of_pinned_posts = self.session.order_buffer(self.name, pinned_posts)
             if pinned_posts != None and len(pinned_posts) > 0:
                 number_of_items = amount_of_pinned_posts+number_of_items
             log.debug("Number of items retrieved: %d" % (number_of_items,))

--- a/src/controller/buffers/mastodon/base.py
+++ b/src/controller/buffers/mastodon/base.py
@@ -108,13 +108,24 @@ class BaseBuffer(base.Buffer):
                     min_id = self.session.db[self.name][0].id
                 else:
                     min_id = self.session.db[self.name][-1].id
+            # loads pinned posts from user accounts.
+            # Load those posts only when there are no items previously loaded.
+            if "-timeline" in self.name and "account_statuses" in self.function and len(self.session.db.get(self.name, [])) == 0:
+                pinned_posts = self.session.api.account_statuses(pinned=True, limit=count, *self.args, **self.kwargs)
+                pinned_posts.reverse()
+            else:
+                pinned_posts = None
             try:
                 results = getattr(self.session.api, self.function)(min_id=min_id, limit=count, *self.args, **self.kwargs)
                 results.reverse()
             except Exception as e:
                 log.exception("Error %s" % (str(e)))
                 return
+            if pinned_posts != None and len(pinned_posts) > 0:
+                amount_of_pinned_posts = self.session.order_buffer(self.name, pinned_posts)
             number_of_items = self.session.order_buffer(self.name, results)
+            if pinned_posts != None and len(pinned_posts) > 0:
+                number_of_items = amount_of_pinned_posts+number_of_items
             log.debug("Number of items retrieved: %d" % (number_of_items,))
             if hasattr(self, "finished_timeline") and self.finished_timeline == False:
                 if "-timeline" in self.name:

--- a/src/sessions/mastodon/templates.py
+++ b/src/sessions/mastodon/templates.py
@@ -90,7 +90,7 @@ def render_post(post, template, settings, relative_times=False, offset_hours=0):
         image_descriptions = process_image_descriptions(post.media_attachments)
     available_data.update(image_descriptions=image_descriptions)
     # Process if the post is pinned
-    if post.pinned:
+    if post.get("pinned", False):
         pinned = _("Pinned.")
     else:
         pinned = ""

--- a/src/sessions/mastodon/templates.py
+++ b/src/sessions/mastodon/templates.py
@@ -9,7 +9,7 @@ from . import utils, compose
 # This will be used for the edit template dialog.
 # Available variables for post objects.
 # safe_text will be the content warning in case a post contains one, text will always be the full text, no matter if has a content warning or not.
-post_variables = ["date", "display_name", "screen_name", "source", "lang", "safe_text", "text", "image_descriptions", "visibility"]
+post_variables = ["date", "display_name", "screen_name", "source", "lang", "safe_text", "text", "image_descriptions", "visibility", "pinned"]
 person_variables = ["display_name", "screen_name", "description", "followers", "following", "favorites", "posts", "created_at"]
 conversation_variables = ["users", "last_post"]
 notification_variables = ["display_name", "screen_name", "text", "date"]
@@ -57,6 +57,7 @@ def render_post(post, template, settings, relative_times=False, offset_hours=0):
     $text: Toot text. This always displays the full text, even if there is a content warning present.
     $image_descriptions: Information regarding image descriptions added by twitter users.
     $visibility: post's visibility: public, not listed, followers only or direct.
+    $pinned: Wether the post is pinned or not (if not pinned, this will be blank).
     """
     global post_variables
     available_data = dict(source="")
@@ -88,6 +89,12 @@ def render_post(post, template, settings, relative_times=False, offset_hours=0):
     else:
         image_descriptions = process_image_descriptions(post.media_attachments)
     available_data.update(image_descriptions=image_descriptions)
+    # Process if the post is pinned
+    if post.pinned:
+        pinned = _("Pinned.")
+    else:
+        pinned = ""
+    available_data.update(pinned=pinned)
     result = Template(_(template)).safe_substitute(**available_data)
     return result
 


### PR DESCRIPTION
This PR should add the loading of pinned posts for users. This still would need some thinking, as for example, pinned posts should remain at the top of the list even when previous items were fetched or not? Also this adds a new variable to posts templates $pinned, which will indicate whether the focused post is pinned by the author or not.