### PR TITLE
Revert "Bump setuptools from 69.0.0 to 70.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ requests==2.32.3
 requests-oauthlib==2.0.0
 requests-toolbelt==1.0.0
 rfc3986==2.0.0
-setuptools==70.0.0
+setuptools==69.0.0
 six==1.17.0
 sniffio==1.3.1
 sound_lib @ git+https://github.com/accessibleapps/sound_lib@a439f0943fb95ee7b6ba24f51a686f47c4ad66b2


### PR DESCRIPTION
Setuptools should be kept for now in 69.0.0 as there are an issue with the latest version and packages that use backports. More details at https://github.com/pypa/setuptools/issues/4509