### PR TITLE
Fix empty Bluesky home timeline and missing image descriptions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -56,4 +56,4 @@ winpaths==0.2
 wxPython==4.2.5
 youtube-dl==2021.12.17
 zipp==4.1.0
-atproto>=0.0.67
+atproto>=0.0.68

--- a/src/blueski.defaults
+++ b/src/blueski.defaults
@@ -44,7 +44,7 @@ braille_reporting = boolean(default=True)
 speech_reporting = boolean(default=True)
 
 [templates]
-post = string(default="$display_name, $reply_to$safe_text $date.")
+post = string(default="$display_name, $reply_to$safe_text $image_descriptions $date.")
 person = string(default="$display_name (@$screen_name). $followers followers, $following following, $posts posts. Joined $created_at.")
 notification = string(default="$display_name $text, $date")
 

--- a/src/controller/blueski/handler.py
+++ b/src/controller/blueski/handler.py
@@ -357,7 +357,7 @@ class Handler:
                     buffer.session.settings["templates"] = {}
                 templates_cfg = buffer.session.settings.get("templates", {})
                 template_state = {
-                    "post": templates_cfg.get("post", "$display_name, $reply_to$safe_text $date."),
+                    "post": templates_cfg.get("post", "$display_name, $reply_to$safe_text $image_descriptions $date."),
                     "person": templates_cfg.get("person", "$display_name (@$screen_name). $followers followers, $following following, $posts posts. Joined $created_at."),
                     "notification": templates_cfg.get("notification", "$display_name $text, $date"),
                 }

--- a/src/controller/buffers/blueski/base.py
+++ b/src/controller/buffers/blueski/base.py
@@ -804,12 +804,12 @@ class BaseBuffer(base.Buffer):
          try:
              if self.type == "notifications":
                  template = template_settings.get("notification", "$display_name $text, $date")
-                 post_template = template_settings.get("post", "$display_name, $reply_to$safe_text $date.")
+                 post_template = template_settings.get("post", "$display_name, $reply_to$safe_text $image_descriptions $date.")
                  return templates.render_notification(item, template, post_template, self.session.settings, relative_times, offset_hours)
              if self.type in ("user", "post_user_list"):
                  template = template_settings.get("person", "$display_name (@$screen_name). $followers followers, $following following, $posts posts. Joined $created_at.")
                  return templates.render_user(item, template, self.session.settings, relative_times, offset_hours)
-             template = template_settings.get("post", "$display_name, $reply_to$safe_text $date.")
+             template = template_settings.get("post", "$display_name, $reply_to$safe_text $image_descriptions $date.")
              return templates.render_post(item, template, self.session.settings, relative_times, offset_hours)
          except Exception:
              # Fallback to compose if any template render fails.

--- a/src/sessions/blueski/compose.py
+++ b/src/sessions/blueski/compose.py
@@ -136,6 +136,11 @@ def compose_post(post, db, settings, relative_times, show_screen_names=False, sa
             if images:
                 text += f" [{len(images)} {_('images')}]"
 
+        if etype and ("gallery" in etype):
+            items = g(embed, "items", [])
+            if items:
+                text += f" [{len(items)} {_('images')}]"
+
         if etype and ("recordWithMedia" in etype):
             media = g(embed, "media", {})
             mtype = g(media, "$type") or g(media, "py_type")
@@ -143,6 +148,10 @@ def compose_post(post, db, settings, relative_times, show_screen_names=False, sa
                 images = g(media, "images", [])
                 if images:
                     text += f" [{len(images)} {_('images')}]"
+            elif mtype and "gallery" in mtype:
+                items = g(media, "items", [])
+                if items:
+                    text += f" [{len(items)} {_('images')}]"
             elif mtype and "external" in mtype:
                 ext = g(media, "external", {})
                 title = g(ext, "title", "")

--- a/src/sessions/blueski/session.py
+++ b/src/sessions/blueski/session.py
@@ -96,6 +96,18 @@ class Session(base.baseSession):
                     self.settings.write()
                 except Exception:
                     pass
+            # Upgrade old default post templates so image descriptions are read.
+            old_post_templates = (
+                "$display_name, $safe_text $date.",
+                "$display_name, $reply_to$safe_text $date.",
+            )
+            templates_cfg = self.settings.get("templates")
+            if templates_cfg is not None and templates_cfg.get("post") in old_post_templates:
+                templates_cfg["post"] = "$display_name, $reply_to$safe_text $image_descriptions $date."
+                try:
+                    self.settings.write()
+                except Exception:
+                    pass
         except Exception:
             log.exception("Failed to migrate legacy Blueski settings")
 

--- a/src/sessions/blueski/templates.py
+++ b/src/sessions/blueski/templates.py
@@ -69,9 +69,13 @@ def _extract_image_descriptions(post, record):
             mtype = _g(media, "$type") or _g(media, "py_type") or ""
             if "images" in mtype:
                 return list(_g(media, "images", []) or [])
+            if "gallery" in mtype:
+                return list(_g(media, "items", []) or [])
             return []
         if "images" in etype:
             return list(_g(embed, "images", []) or [])
+        if "gallery" in etype:
+            return list(_g(embed, "items", []) or [])
         return []
 
     images = []

--- a/src/sessions/blueski/utils.py
+++ b/src/sessions/blueski/utils.py
@@ -78,7 +78,7 @@ def _extract_images_from_embed(embed):
         for img in (img_list or []):
             url = None
             # Try all possible URL field names
-            for key in ["fullsize", "thumb", "url", "uri", "src"]:
+            for key in ["fullsize", "thumb", "thumbnail", "url", "uri", "src"]:
                 val = g(img, key)
                 if val and isinstance(val, str) and val.startswith("http"):
                     url = val
@@ -103,12 +103,18 @@ def _extract_images_from_embed(embed):
     if "images" in etype.lower():
         images.extend(extract_images(g(embed, "images", [])))
 
+    # Gallery embed (app.bsky.embed.gallery or app.bsky.embed.gallery#view)
+    if "gallery" in etype.lower():
+        images.extend(extract_images(g(embed, "items", [])))
+
     # Check in recordWithMedia wrapper
     if "recordwithmedia" in etype.lower():
         media = g(embed, "media", {})
         mtype = g(media, "$type") or g(media, "py_type") or ""
         if "images" in mtype.lower():
             images.extend(extract_images(g(media, "images", [])))
+        if "gallery" in mtype.lower():
+            images.extend(extract_images(g(media, "items", [])))
 
     return images
 
@@ -136,6 +142,12 @@ def is_image(post):
         if images and len(images) > 0:
             return True
 
+    # Gallery embed
+    if "gallery" in etype.lower():
+        items = g(embed, "items", [])
+        if items and len(items) > 0:
+            return True
+
     # Check in recordWithMedia wrapper
     if "recordwithmedia" in etype.lower():
         media = g(embed, "media", {})
@@ -143,6 +155,10 @@ def is_image(post):
         if "images" in mtype.lower():
             images = g(media, "images", [])
             if images and len(images) > 0:
+                return True
+        if "gallery" in mtype.lower():
+            items = g(media, "items", [])
+            if items and len(items) > 0:
                 return True
 
     return False


### PR DESCRIPTION
## Summary

Two regressions in the Bluesky integration:

1. **Home timeline loaded 0 items.** Bluesky started returning the new `app.bsky.embed.gallery#view` embed type. atproto `< 0.0.68` cannot parse it, so the *entire* `get_timeline` response failed pydantic validation (`union_tag_invalid`) and the buffer fell back to 0 items. Observed in `logs/error.log`:

   ```
   Error fetching following timeline: 1 validation error for Response
   feed.3.post.embed
     Input tag 'app.bsky.embed.gallery#view' ... does not match any of the expected tags
   ```

2. **Image alt texts were never read**, even when present, because the default Bluesky post template did not include `$image_descriptions`.

## Changes

- Bump `atproto` to `>=0.0.68` (adds `gallery` embed model).
- Add `gallery` embed support across the helpers: image detection (`is_image`), media/OCR URL extraction (`_extract_images_from_embed`, including the `thumbnail` URL field), the `[N images]` indicator in `compose_post`, and `_extract_image_descriptions` in templates. RecordWithMedia wrappers handled too.
- Add `$image_descriptions` to the default post template in `blueski.defaults` and to the hardcoded fallbacks.
- Migrate existing sessions still using an old default post template so alt descriptions are read without manual reconfiguration.

## Testing

Verified manually: the Home buffer now populates and image alt descriptions are announced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)